### PR TITLE
[RPC] Matching http2 with writer for java-grpc compatibility

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -134,7 +134,7 @@ func (ns *RPC) serve() {
 
 	// Setup TCP multiplexer
 	tcpm := cmux.New(l)
-	grpcL := tcpm.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	grpcL := tcpm.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := tcpm.Match(cmux.HTTP1Fast())
 
 	ns.log.Info().Msg(fmt.Sprintf("Starting RPC server listening on %s, with TLS: %v", addr, ns.conf.RPC.NSEnableTLS))


### PR DESCRIPTION
I found that java gRPC client is not compatible with current matcher.

According to [cmux repository](https://github.com/soheilhy/cmux), use MatchWithWriter when using grpc java client.

But we have to check MatchWithWriter version is compatible with [herajs](https://github.com/aergoio/herajs). Maybe @graup have to test it.