### PR TITLE
[accounts] new address format

### DIFF
--- a/account/accountservice.go
+++ b/account/accountservice.go
@@ -1,7 +1,6 @@
 package account
 
 import (
-	"encoding/base64"
 	"sync"
 
 	"github.com/aergoio/aergo/account/key"
@@ -77,16 +76,6 @@ func (as *AccountService) Receive(context actor.Context) {
 			context.Respond(&message.VerifyTxRsp{Tx: msg.Tx, Err: nil})
 		}
 	}
-}
-
-//TODO: refactoring util function
-func EncodeB64(bs []byte) string {
-	return base64.StdEncoding.EncodeToString(bs)
-}
-
-func DecodeB64(sb string) []byte {
-	buf, _ := base64.StdEncoding.DecodeString(sb)
-	return buf
 }
 
 func (as *AccountService) getAccounts() []*types.Account {

--- a/account/accountservice_test.go
+++ b/account/accountservice_test.go
@@ -185,10 +185,10 @@ func TestVerfiyFail(t *testing.T) {
 func TestBase58CheckEncoding(t *testing.T) {
 	initTest()
 	defer deinitTest()
-	addr := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+	addr := []byte{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33}
 
 	encoded := types.EncodeAddress(addr)
-	expected := "AFsCjUGzicZmXQtWpwVt6fQTZyaVe7bfEk"
+	expected := "AmJaNDXoPbBRn9XHh9onKbDKuAzj88n5Bzt7KniYA78qUEc5EwBd"
 	if encoded != expected {
 		t.Fatalf("incorrectly encoded address: %s should be %s", encoded, expected)
 	}
@@ -198,7 +198,7 @@ func TestBase58CheckEncoding(t *testing.T) {
 		t.Fatalf("incorrectly decoded address: %x should be %x", decoded, addr)
 	}
 
-	_, err := types.DecodeAddress("EFsCjUGzicZmXQtWpwVt6fQTZyaVe7bfEk")
+	_, err := types.DecodeAddress("AmJaNDXoPbBRn9XHh9onKbDKuAzj88n5Bzt7KniYA78qUEc5EwBA")
 	if err == nil {
 		t.Fatalf("decoding address with wrong checksum should error")
 	}

--- a/account/accountservice_test.go
+++ b/account/accountservice_test.go
@@ -21,7 +21,7 @@ var (
 	conf           *config.Config
 )
 
-const AddressLength = 20
+const AddressLength = 33
 
 func initTest() {
 	serverCtx := config.NewServerContext("", "")

--- a/account/key/address.go
+++ b/account/key/address.go
@@ -10,11 +10,14 @@ import (
 
 type Address = []byte
 
+const addressLength = 33
+
 func GenerateAddress(pubkey *ecdsa.PublicKey) []byte {
 	addr := new(bytes.Buffer)
+	// Compressed pubkey
 	binary.Write(addr, binary.LittleEndian, pubkey.X.Bytes())
-	binary.Write(addr, binary.LittleEndian, pubkey.Y.Bytes())
-	return addr.Bytes()[:20] //TODO: ADDRESSLENGTH ?
+	binary.Write(addr, binary.LittleEndian, uint8(0x2 + pubkey.Y.Bit(0)))  // 0x2 for even, 0x3 for odd Y
+	return addr.Bytes()
 }
 
 func (ks *Store) SaveAddress(addr Address) error {
@@ -30,7 +33,6 @@ func (ks *Store) SaveAddress(addr Address) error {
 }
 
 func (ks *Store) GetAddresses() ([]Address, error) {
-	const addressLength = 20
 	b, err := ioutil.ReadFile(ks.addresses)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/account/key/address.go
+++ b/account/key/address.go
@@ -1,23 +1,21 @@
 package key
 
 import (
-	"bytes"
 	"crypto/ecdsa"
-	"encoding/binary"
 	"io/ioutil"
 	"os"
+	"crypto/sha256"
 )
 
 type Address = []byte
 
-const addressLength = 33
+const addressLength = 20
 
 func GenerateAddress(pubkey *ecdsa.PublicKey) []byte {
-	addr := new(bytes.Buffer)
-	// Compressed pubkey
-	binary.Write(addr, binary.LittleEndian, pubkey.X.Bytes())
-	binary.Write(addr, binary.LittleEndian, uint8(0x2 + pubkey.Y.Bit(0)))  // 0x2 for even, 0x3 for odd Y
-	return addr.Bytes()
+	h := sha256.New()
+	h.Write(pubkey.X.Bytes())
+	h.Write(pubkey.Y.Bytes())
+	return h.Sum(nil)[:addressLength]
 }
 
 func (ks *Store) SaveAddress(addr Address) error {

--- a/account/key/sign.go
+++ b/account/key/sign.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aergoio/aergo/message"
 	"github.com/aergoio/aergo/types"
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/mr-tron/base58/base58"
 )
 
 //Sign return sign with key in the store
@@ -37,7 +36,7 @@ func SignTx(tx *types.Tx, key *aergokey) error {
 //SignTx return transaction which signed with unlocked key
 func (ks *Store) SignTx(tx *types.Tx) error {
 	addr := tx.Body.Account
-	key, exist := ks.unlocked[base58.Encode(addr)]
+	key, exist := ks.unlocked[types.EncodeAddress(addr)]
 	if !exist {
 		return message.ErrShouldUnlockAccount
 	}

--- a/account/key/store.go
+++ b/account/key/store.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/message"
+	"github.com/aergoio/aergo/types"
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/mr-tron/base58/base58"
 )
 
 type aergokey = btcec.PrivateKey
@@ -70,7 +70,7 @@ func (ks *Store) Unlock(addr Address, pass string) (Address, error) {
 	if key == nil {
 		return nil, err
 	}
-	ks.unlocked[base58.Encode(addr)], _ = btcec.PrivKeyFromBytes(btcec.S256(), key)
+	ks.unlocked[types.EncodeAddress(addr)], _ = btcec.PrivKeyFromBytes(btcec.S256(), key)
 	return addr, nil
 }
 
@@ -79,7 +79,7 @@ func (ks *Store) Lock(addr Address, pass string) (Address, error) {
 	if key == nil {
 		return nil, err
 	}
-	b58addr := base58.Encode(addr)
+	b58addr := types.EncodeAddress(addr)
 	ks.unlocked[b58addr] = nil
 	delete(ks.unlocked, b58addr)
 	return addr, nil

--- a/blockchain/chainhandle.go
+++ b/blockchain/chainhandle.go
@@ -367,6 +367,7 @@ func executeTx(sdb *state.ChainStateDB, bs *types.BlockState, receiptTx db.Trans
 		receiverID = types.ToAccountID(recipient)
 	} else {
 		createContract = true
+		// Determine new contract address
 		h := sha256.New()
 		h.Write(txBody.Account)
 		h.Write([]byte(strconv.FormatUint(txBody.Nonce, 10)))

--- a/blockchain/chainhandle.go
+++ b/blockchain/chainhandle.go
@@ -371,7 +371,8 @@ func executeTx(sdb *state.ChainStateDB, bs *types.BlockState, receiptTx db.Trans
 		h := sha256.New()
 		h.Write(txBody.Account)
 		h.Write([]byte(strconv.FormatUint(txBody.Nonce, 10)))
-		recipient = h.Sum(nil)[:20]
+		recipientHash := h.Sum(nil) // byte array with length 32
+		recipient = append([]byte{0x0C}, recipientHash...) // prepend 0x0C to make it same length as account addresses
 		receiverID = types.ToAccountID(recipient)
 	}
 	receiverState, err := sdb.GetBlockAccountClone(bs, receiverID)

--- a/cmd/aergocli/cmd/accounts.go
+++ b/cmd/aergocli/cmd/accounts.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/mr-tron/base58/base58"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/aergoio/aergo/account/key"
@@ -72,9 +71,9 @@ var newAccountCmd = &cobra.Command{
 			fmt.Printf("Failed: %s\n", err.Error())
 		} else {
 			if msg != nil {
-				fmt.Println(base58.Encode(msg.GetAddress()))
+				fmt.Println(types.EncodeAddress(msg.GetAddress()))
 			} else {
-				fmt.Println(base58.Encode(addr))
+				fmt.Println(types.EncodeAddress(addr))
 			}
 		}
 	},
@@ -111,14 +110,14 @@ var getAccountsCmd = &cobra.Command{
 			if msg != nil {
 				addresslist := msg.GetAccounts()
 				for _, a := range addresslist {
-					out = fmt.Sprintf("%s%s, ", out, base58.Encode(a.Address))
+					out = fmt.Sprintf("%s%s, ", out, types.EncodeAddress(a.Address))
 				}
 				if addresslist != nil {
 					out = out[:len(out)-2]
 				}
 			} else if addrs != nil {
 				for _, a := range addrs {
-					out = fmt.Sprintf("%s%s, ", out, base58.Encode(a))
+					out = fmt.Sprintf("%s%s, ", out, types.EncodeAddress(a))
 				}
 				out = out[:len(out)-2]
 			}
@@ -143,7 +142,7 @@ var lockAccountCmd = &cobra.Command{
 		}
 		msg, err := client.LockAccount(context.Background(), param)
 		if err == nil {
-			fmt.Println(base58.Encode(msg.GetAddress()))
+			fmt.Println(types.EncodeAddress(msg.GetAddress()))
 		} else {
 			fmt.Printf("Failed: %s\n", err.Error())
 		}
@@ -162,7 +161,7 @@ var unlockAccountCmd = &cobra.Command{
 		}
 		msg, err := client.UnlockAccount(context.Background(), param)
 		if nil == err {
-			fmt.Println(base58.Encode(msg.GetAddress()))
+			fmt.Println(types.EncodeAddress(msg.GetAddress()))
 		} else {
 			fmt.Printf("Failed: %s\n", err.Error())
 		}
@@ -173,7 +172,7 @@ func parsePersonalParam() (*types.Personal, error) {
 	var err error
 	param := &types.Personal{Account: &types.Account{}}
 	if address != "" {
-		param.Account.Address, err = base58.Decode(address)
+		param.Account.Address, err = types.DecodeAddress(address)
 		if err != nil {
 			fmt.Printf("Failed: %s\n", err.Error())
 			return nil, err

--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/aergoio/aergo/cmd/aergocli/util"
 	"github.com/aergoio/aergo/types"
-	"github.com/mr-tron/base58/base58"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 )
@@ -63,7 +62,7 @@ func init() {
 
 func runDeployCmd(cmd *cobra.Command, args []string) {
 	var err error
-	creator, err := base58.Decode(args[0])
+	creator, err := types.DecodeAddress(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -93,7 +92,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 		copy(payload[4:], code)
 		copy(payload[4+len(code):], abi)
 	} else {
-		payload, err = base58.Decode(data)
+		payload, err = types.DecodeAddress(data)
 		if err != nil {
 			fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
@@ -123,7 +122,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) {
 }
 
 func runCallCmd(cmd *cobra.Command, args []string) {
-	caller, err := base58.Decode(args[0])
+	caller, err := types.DecodeAddress(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -131,7 +130,7 @@ func runCallCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	contract, err := base58.Decode(args[1])
+	contract, err := types.DecodeAddress(args[1])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -172,7 +171,7 @@ func runCallCmd(cmd *cobra.Command, args []string) {
 }
 
 func runGetABICmd(cmd *cobra.Command, args []string) {
-	contract, err := base58.Decode(args[0])
+	contract, err := types.DecodeAddress(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -184,7 +183,7 @@ func runGetABICmd(cmd *cobra.Command, args []string) {
 }
 
 func runQueryCmd(cmd *cobra.Command, args []string) {
-	contract, err := base58.Decode(args[0])
+	contract, err := types.DecodeAddress(args[0])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/aergocli/cmd/getstate.go
+++ b/cmd/aergocli/cmd/getstate.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mr-tron/base58/base58"
-
 	"github.com/aergoio/aergo/cmd/aergocli/util"
 	"github.com/aergoio/aergo/types"
 	"github.com/spf13/cobra"
@@ -43,7 +41,7 @@ func execGetState(cmd *cobra.Command, args []string) {
 		fmt.Println("no --address specified")
 		return
 	}
-	param, err := base58.Decode(address)
+	param, err := types.DecodeAddress(address)
 	if err != nil {
 		fmt.Printf("Failed: %s\n", err.Error())
 	}

--- a/cmd/aergocli/cmd/signtx.go
+++ b/cmd/aergocli/cmd/signtx.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mr-tron/base58/base58"
-
 	"github.com/aergoio/aergo/account/key"
 	"github.com/aergoio/aergo/cmd/aergocli/util"
 	"github.com/aergoio/aergo/types"
@@ -65,7 +63,7 @@ var signCmd = &cobra.Command{
 
 			dataEnvPath := os.ExpandEnv(dataDir)
 			ks := key.NewStore(dataEnvPath)
-			addr, err := base58.Decode(address)
+			addr, err := types.DecodeAddress(address)
 			if err != nil {
 				fmt.Printf("Failed: %s\n", err.Error())
 				return

--- a/cmd/aergocli/cmd/vote.go
+++ b/cmd/aergocli/cmd/vote.go
@@ -46,7 +46,7 @@ var voteCmd = &cobra.Command{
 const peerIDLength = 39
 
 func execVote(cmd *cobra.Command, args []string) {
-	account, err := base58.Decode(from)
+	account, err := types.DecodeAddress(from)
 	if err != nil {
 		fmt.Printf("Failed: %s\n", err.Error())
 		return
@@ -143,6 +143,6 @@ func execVoteStat(cmd *cobra.Command, args []string) {
 		return
 	}
 	for i, r := range msg.GetVotes() {
-		fmt.Println(i+1, " : ", base58.Encode(r.Candidate), " : ", r.Amount)
+		fmt.Println(i+1, " : ", types.EncodeAddress(r.Candidate), " : ", r.Amount)
 	}
 }

--- a/contract/vm_test.go
+++ b/contract/vm_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 const (
-	accountId = "31KcyXb99xYD5tQ9Jpx4BMnhVh9a"
+	accountId = "AnZNgPahfxH1pE8DkLFCt3uEQZBbivmxsF1s2QbHG7J6owEV2qh6"
 	txId      = "c2b36750"
 	/*function hello(say) return "Hello " .. say end abi.register(hello)*/
 	helloCode = "C34wJetPFqYBV8bpSao36R2NxFcW5X4ZGZoPcnfJvHkvvBR4PcbsZ5xki8nSHubPMnNusFPpn19x7myhR8baq12RvoufQ8z2DR1PyvGfYf6VmAzhF5rg8F7mvVEBRdqnAMnFmb5E6E2iey4wEjXNrjJ8RfsPEfottZ2umDN5WFc8egeydXesa1a59QLBp926MoETbDwRJMeFHeGHuvQ4bikCXhXaQS6Vi73y4Xpcu3Bv1rMnfBxEX5ZehtcuYDFUoZzn8"
@@ -60,7 +60,7 @@ func init() {
 	DB = db.NewDB(db.BadgerImpl, path.Join(tmpDir, "receiptDB"))
 
 	var err error
-	aid, err = base58.Decode(accountId)
+	aid, err = types.DecodeAddress(accountId)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
@@ -121,8 +121,9 @@ func TestContractSystem(t *testing.T) {
 	contractCall(t, contractState, callInfo, bcCtx)
 	receipt := types.NewReceiptFromBytes(DB.Get(tid))
 
-	if receipt.GetRet() != "[\"6hu2huFGTzbncMV\",\"c2b36750\",\"AUu39krB88UbRXM1hT37zZgk3MuS8aLGgF\",1234,100,999]" {
-		t.Errorf("contract Call ret error :%s\n", receipt.GetRet())
+	// sender, txhash, contractid, timestamp, blockheight, getItem("key1")
+	if receipt.GetRet() != "[\"HNM6akcic1ou1fX\",\"c2b36750\",\"AnZNgPahfxH1pE8DkLFCt3uEQZBbivmxsF1s2QbHG7J6owEV2qh6\",1234,100,999]" {
+		t.Errorf("contract Call ret error: %s\n", receipt.GetRet())
 	}
 
 }

--- a/contract/vm_test.go
+++ b/contract/vm_test.go
@@ -121,7 +121,7 @@ func TestContractSystem(t *testing.T) {
 	contractCall(t, contractState, callInfo, bcCtx)
 	receipt := types.NewReceiptFromBytes(DB.Get(tid))
 
-	if receipt.GetRet() != "[\"sender2\",\"c2b36750\",\"31KcyXb99xYD5tQ9Jpx4BMnhVh9a\",1234,100,999]" {
+	if receipt.GetRet() != "[\"6hu2huFGTzbncMV\",\"c2b36750\",\"AUu39krB88UbRXM1hT37zZgk3MuS8aLGgF\",1234,100,999]" {
 		t.Errorf("contract Call ret error :%s\n", receipt.GetRet())
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6d07dfbfcc47a436b2d415423b576ccfedc7b3c6386ffff2c7acdc027cc7ecf5
-updated: 2018-09-13T19:45:45.5725836+09:00
+hash: bef90f2a4379c9b04ca54081eb0bb7fc8b4d32edecdf9110686077523a050ae9
+updated: 2018-09-14T11:26:10.068355+09:00
 imports:
 - name: github.com/aergoio/aergo-actor
   version: c64cbdbabc820bb9bdd772303bf96f56e7c9005a
@@ -20,6 +20,8 @@ imports:
   subpackages:
   - edwards25519
   - extra25519
+- name: github.com/anaskhan96/base58check
+  version: fcff33ba49dde3181fa69fb346f45582e52a3815
 - name: github.com/AndreasBriese/bbloom
   version: 28f7e881ca57bc00e028f9ede9f0d9104cfeef5e
 - name: github.com/btcsuite/btcd

--- a/glide.yaml
+++ b/glide.yaml
@@ -73,6 +73,7 @@ import:
   version: ~0.1.4
 - package: github.com/aergoio/aergo-lib
 - package: github.com/minio/sha256-simd
+- package: github.com/anaskhan96/base58check
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.2.2

--- a/types/account.go
+++ b/types/account.go
@@ -36,7 +36,7 @@ func NewAccountList(accounts []*Account) *AccountList {
 }
 
 type Address = []byte
-const AddressVersion = 0x17
+const AddressVersion = 0x42
 
 func EncodeAddress(addr Address) (string) {
 	encoded, _ := base58check.Encode(fmt.Sprintf("%x", AddressVersion), hex.EncodeToString(addr))

--- a/types/account.go
+++ b/types/account.go
@@ -1,6 +1,11 @@
 package types
 
-import "github.com/mr-tron/base58/base58"
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"github.com/anaskhan96/base58check"
+)
 
 //NewAccount alloc new account object
 func NewAccount(addr []byte) *Account {
@@ -9,18 +14,18 @@ func NewAccount(addr []byte) *Account {
 	}
 }
 
-//ToAddress return byte array of given address string
+//ToAddress return byte array of given base58check encoded address string
 func ToAddress(addr string) []byte {
-	ret, err := base58.Decode(addr)
+	ret, err := DecodeAddress(addr)
 	if err != nil {
 		return nil
 	}
 	return ret
 }
 
-//ToString return base64 encoded string of address
+//ToString return base58check encoded string of address
 func (a *Account) ToString() string {
-	return base58.Encode(a.Address)
+	return EncodeAddress(a.Address)
 }
 
 //NewAccountList alloc new account list
@@ -28,4 +33,29 @@ func NewAccountList(accounts []*Account) *AccountList {
 	return &AccountList{
 		Accounts: accounts,
 	}
+}
+
+type Address = []byte
+const AddressVersion = 0x17
+
+func EncodeAddress(addr Address) (string) {
+	encoded, _ := base58check.Encode(fmt.Sprintf("%x", AddressVersion), hex.EncodeToString(addr))
+	return encoded
+}
+
+func DecodeAddress(encodedAddr string) (Address, error) {
+	decodedString, err := base58check.Decode(encodedAddr)
+	if err != nil {
+		return nil, err
+	}
+	decodedBytes, err := hex.DecodeString(decodedString)
+	if err != nil {
+		return nil, err
+	}
+	version := decodedBytes[0]
+	if version != AddressVersion {
+		return nil, errors.New("Invalid address version")
+	}
+	decoded := decodedBytes[1:]
+	return decoded, nil
 }

--- a/types/receipt.go
+++ b/types/receipt.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/gogo/protobuf/jsonpb"
-	"github.com/mr-tron/base58/base58"
 	"strings"
 )
 
@@ -41,7 +40,7 @@ func (r Receipt) MarshalJSONPB(*jsonpb.Marshaler) ([]byte, error) {
 func (r Receipt) MarshalJSON() ([]byte, error) {
 	var b bytes.Buffer
 	b.WriteString(`{"contractAddress":"`)
-	b.WriteString(base58.Encode(r.ContractAddress))
+	b.WriteString(EncodeAddress(r.ContractAddress))
 	b.WriteString(`","status":"`)
 	b.WriteString(strings.Replace(r.Status, "\"", "'", -1))
 	b.WriteString(`","ret":"`)


### PR DESCRIPTION
I refactored the address encoding/decoding into the `types` package (`EncodeAddress`, `DecodeAddress`). Please use these instead of the direct calls to base58! The new scheme uses base58check.

I also adjusted the account address generation to use the last 20 bytes of a hash of the pubkey, like Ethereum does.

I changed almost all occurrences of `base58` in the codebase to use the new `EncodeAddress` function, but it is possible I missed something.