### PR TITLE
[CLI] Fix when importing account

### DIFF
--- a/cmd/aergocli/cmd/accounts.go
+++ b/cmd/aergocli/cmd/accounts.go
@@ -205,7 +205,7 @@ var importCmd = &cobra.Command{
 		if to != "" {
 			wif.Newpass = to
 		} else {
-			wif.Newpass = pw
+			wif.Newpass = wif.Oldpass
 		}
 
 		if cmd.Flags().Changed("path") == false {


### PR DESCRIPTION
When both --password and --newpassword target is empty, cmd guide to type password. But that password isn't used as an new password.