### PR TITLE
[cli] keygen --json option to export address and encrypted privkey

### DIFF
--- a/account/key/store.go
+++ b/account/key/store.go
@@ -79,6 +79,11 @@ func (ks *Store) ExportKey(addr Address, pass string) ([]byte, error) {
 	if key == nil {
 		return nil, err
 	}
+	return EncryptKey(key, pass)
+}
+
+// EncryptKey encrypts a key with a given export for exporting
+func EncryptKey(key []byte, pass string) ([]byte, error) {
 	hash := hashBytes([]byte(pass), nil)
 	rehash := hashBytes([]byte(pass), hash)
 	return encrypt(hash, rehash, key)

--- a/cmd/aergocli/cmd/keygen.go
+++ b/cmd/aergocli/cmd/keygen.go
@@ -1,23 +1,38 @@
 package cmd
 
 import (
+	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/aergoio/aergo/account/key"
+	"github.com/aergoio/aergo/types"
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/libp2p/go-libp2p-peer"
 	"github.com/spf13/cobra"
 )
 
+type keyJson struct {
+	Address string `json:"address"`
+	PubKey  string `json:"pubkey"`
+	PrivKey string `json:"privkey"`
+	Id      string `json:"id"`
+}
+
 var (
 	genPubkey bool
 	genID     bool
+	genJSON   bool
+	password  string
 )
 
 func init() {
 	//keygenCmd.Flags().StringVar(&prefix, "prefix", "nodekey", "prefix name of key file")
 	//keygenCmd.Flags().BoolVar(&genPubkey, "genpubkey", true, "also generate public key")
-	//keygenCmd.Flags().BoolVar(&genID, "genid", true, "also generate id")
+	keygenCmd.Flags().BoolVar(&genJSON, "json", false, "also generate combined json file")
+	keygenCmd.Flags().StringVar(&password, "password", "", "password for encrypted private key in json file")
 
 	rootCmd.AddCommand(keygenCmd)
 }
@@ -49,25 +64,25 @@ func generateKey(prefix string) error {
 	pkFile := prefix + ".key"
 	pubFile := prefix + ".pub"
 	idFile := prefix + ".id"
+	jsonFile := prefix + ".json"
 
+	// Write private key file
 	pkf, err := os.Create(pkFile)
 	if err != nil {
 		return err
 	}
-
 	pkBytes, err := priv.Bytes()
 	if err != nil {
 		return err
 	}
 	pkf.Write(pkBytes)
 	pkf.Sync()
-	fmt.Printf("Key file %s is generated.\n", pkFile)
 
+	// Write public key file
 	pubf, err := os.Create(pubFile)
 	if err != nil {
 		return err
 	}
-
 	pubBytes, err := pub.Bytes()
 	if err != nil {
 		return err
@@ -75,13 +90,48 @@ func generateKey(prefix string) error {
 	pubf.Write(pubBytes)
 	pubf.Sync()
 
+	// Write id file
 	idf, err := os.Create(idFile)
-	idBytes := []byte(peer.IDB58Encode(pid))
 	if err != nil {
 		return err
 	}
+	idBytes := []byte(peer.IDB58Encode(pid))
 	idf.Write(idBytes)
 	idf.Sync()
+
+	// Write combined json file
+	if genJSON {
+		if password == "" {
+			fmt.Printf("Warning: private key in json file encrypted with empty password. Use command line parameter --password.\n")
+		}
+		jsonf, err := os.Create(jsonFile)
+		if err != nil {
+			return err
+		}
+		privKeyExport, err := key.EncryptKey(pkBytes, password)
+		if err != nil {
+			return err
+		}
+		_, pubkey := btcec.PrivKeyFromBytes(btcec.S256(), pkBytes)
+		address := key.GenerateAddress(pubkey.ToECDSA())
+		addressEncoded := types.EncodeAddress(address)
+		jsonMarshalled, err := json.Marshal(keyJson{
+			Address: addressEncoded,
+			PubKey:  b64.StdEncoding.EncodeToString(pubBytes),
+			PrivKey: types.EncodePrivKey(privKeyExport),
+			Id:      peer.IDB58Encode(pid),
+		})
+		if err != nil {
+			return err
+		}
+		jsonf.Write(jsonMarshalled)
+		jsonf.Sync()
+
+		fmt.Printf("New account address: %s\n", addressEncoded)
+		fmt.Printf("Generated key files %s.{key,pub,id,json}.\n", prefix)
+	} else {
+		fmt.Printf("Generated key files %s.{key,pub,id}.\n", prefix)
+	}
 
 	return nil
 }


### PR DESCRIPTION
There's currently no easy way to just generate a private key and address offline (without a server and internet connection). Herajs and Herajs can do that, of course, but if someone just want to quickly make a new account, that's not that easy to use.

I figured that `aergocli keygen` does pretty much exactly that, but it didn't export the new key in the format used by other tools. So I added the option `--json --pasword test` so that the new key's address and encrypted key are exported.