### PR TITLE
Travis build and deploy releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,43 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
-  - "1.10.x"
+  - 1.10.x
 
 before_install:
   - go get -t github.com/Masterminds/glide
-  - go get -t github.com/codeclimate/test-reporter
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then go get -t github.com/codeclimate/test-reporter; fi
   - cmake .
+
+install:
   - make
-  
+
 before_script:
-  - test-reporter before-build
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test-reporter before-build; fi
 
 script:
-  - make cover-check
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make cover-check; fi
 
 after_script:
-  - test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+
+before_deploy:
+  - AERGO_VERSION="${TRAVIS_TAG:1}"
+  - mkdir -p ${AERGO_VERSION}/bin
+  - mkdir -p release
+  - mv bin/{aergocli,aergoluac,aergosvr,brick} ${AERGO_VERSION}/bin
+  - tar -zcvf release/aergo-${AERGO_VERSION}.${TRAVIS_OS_NAME}.tar.gz ${AERGO_VERSION}
+
+deploy:
+  provider: releases
+  api_key:
+    secure: uGFdnqc23aUqoZD9bZqQsGl4KiHAH6WkUrH9mrdgzsb5sXaChhX0J9klJcDEbYOKG19HUeoBHSorwSKl6Bsg+eOqf8E+blNQLNq7CoPcceGkpXBrfmGe3zgXKjrEGDbsEBuR7oA4GcJAYKw+tJEXZ7z4jy6kuJFxn5j3MZqvz0XIKM6/dUiF/0N1sfLrDWWpdBrW2yJt9yHaeqXhhA/IiHVrlj79KYxTU0UFwdBW6CjxLpOoQWaFwW3X94l5/UpKrDXFpwjjCOhceBpm8dHBxbYujDtop/n/R0VdhtVXtdyx/I877e/d5z3fDL6xTuAMnDYbJdqhVVbBoAukbOpYzhksJ7+1dFFEcku6pFfYPMnxjhxNs9AN5b/qAdxauUe167a/XVUOyOUFoZlptZsGO5i9HXCAnLOgyyTMpeeo3ELIJvSQAK5J9l/wz1g0cJboRsu1rM0LmNqynzScJja2MWaH1vXKlFA56Lr0ZtY/N3T7pg+BPucFp4Fp8hedoEIqRZbqWDAlfX4aY8u6BWTS5929ThrXT9Y5PRZplLAW9QdlmHewWZpevCSm5HA60SF7Qz9tUAVTyKzx/GLvLBNyI82M9JggHwK0gVe/fU0NtKewZnwNaJ4uM5LZvJxq6h0+/N6BLBZsLmBbUC3BgodMSdxb9y0rG8ipAWi9dZhEYd0=
+  file_glob: true
+  file: release/*
+  skip_cleanup: true
+  draft: true 
+  on:
+    tags: true


### PR DESCRIPTION
This configuration uses Travis to automatically builds linux and macOS binaries and deploy them to the Github releases page whenever a new tag is added.