### PR TITLE
[name] Refactor code for varification

### DIFF
--- a/chain/blockvalidator.go
+++ b/chain/blockvalidator.go
@@ -8,9 +8,9 @@ package chain
 import (
 	"bytes"
 	"errors"
-	"github.com/aergoio/aergo/pkg/component"
 
 	"github.com/aergoio/aergo/internal/enc"
+	"github.com/aergoio/aergo/pkg/component"
 	"github.com/aergoio/aergo/state"
 	"github.com/aergoio/aergo/types"
 )
@@ -31,7 +31,7 @@ var (
 
 func NewBlockValidator(comm component.IComponentRequester, sdb *state.ChainStateDB) *BlockValidator {
 	bv := BlockValidator{
-		signVerifier: NewSignVerifier(comm, VerifierCount, dfltUseMempool),
+		signVerifier: NewSignVerifier(comm, sdb, VerifierCount, dfltUseMempool),
 		sdb:          sdb,
 	}
 

--- a/chain/signverifier_test.go
+++ b/chain/signverifier_test.go
@@ -36,7 +36,7 @@ func _itobU32(argv uint32) []byte {
 
 func beforeTest(txCount int) error {
 	if verifier == nil {
-		verifier = NewSignVerifier(nil /*types.DefaultVerifierCnt*/, 4, false)
+		verifier = NewSignVerifier(nil /*types.DefaultVerifierCnt*/, nil, 4, false)
 	}
 
 	for i := 0; i < maxAccount; i++ {

--- a/contract/name/execute_test.go
+++ b/contract/name/execute_test.go
@@ -3,6 +3,7 @@ package name
 import (
 	"testing"
 
+	"github.com/aergoio/aergo/state"
 	"github.com/aergoio/aergo/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,16 +12,41 @@ func TestExcuteNameTx(t *testing.T) {
 	initTest(t)
 	defer deinitTest()
 	txBody := &types.TxBody{}
-	scs, err := sdb.GetStateDB().OpenContractStateAccount(types.ToAccountID([]byte("aergo.system")))
-	assert.NoError(t, err, "could not open contract state")
+
 	txBody.Account = types.ToAddress("AmMXVdJ8DnEFysN58cox9RADC74dF1CLrQimKCMdB4XXMkJeuQgL")
 	txBody.Recipient = []byte(types.AergoName)
 
 	name := "AB1234567890"
 	txBody.Payload = buildNamePayload(name, 'c', nil)
-	err = ExecuteNameTx(scs, txBody)
+
+	bs := sdb.NewBlockState(sdb.GetRoot())
+	scs := openContractState(t, bs)
+
+	err := ExecuteNameTx(scs, txBody)
 	assert.NoError(t, err, "execute name tx")
+
+	commitContractState(t, bs, scs)
+
+	scs = openContractState(t, bs)
 	ret := GetAddress(scs, []byte(name))
 	assert.Equal(t, txBody.Account, ret, "pubkey address")
 
+}
+
+func openContractState(t *testing.T, bs *state.BlockState) *state.ContractState {
+	nameContractID := types.ToAccountID([]byte(types.AergoName))
+	nameContract, err := bs.GetAccountState(nameContractID)
+	assert.NoError(t, err, "could not get account state")
+	scs, err := bs.OpenContractState(nameContractID, nameContract)
+	assert.NoError(t, err, "could not open contract state")
+	return scs
+}
+func commitContractState(t *testing.T, bs *state.BlockState, scs *state.ContractState) {
+	bs.StageContractState(scs)
+	bs.Update()
+	bs.Commit()
+}
+func nextBlockContractState(t *testing.T, bs *state.BlockState, scs *state.ContractState) *state.ContractState {
+	commitContractState(t, bs, scs)
+	return openContractState(t, bs)
 }

--- a/contract/name/name.go
+++ b/contract/name/name.go
@@ -94,7 +94,7 @@ func getAddress(scs *state.ContractState, name []byte) []byte {
 func GetOwner(scs *state.ContractState, name []byte) *Owner {
 	lowerCaseName := strings.ToLower(string(name))
 	key := append(prefix, lowerCaseName...)
-	ownergob, err := scs.GetData(key)
+	ownergob, err := scs.GetInitialData(key)
 	if err != nil {
 		return nil
 	}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -279,11 +279,8 @@ Gather:
 func (mp *MemPool) put(tx *types.Tx) error {
 	id := types.ToTxID(tx.GetHash())
 	acc := tx.GetBody().GetAccount()
-	if tx.NeedNameVerify() {
-		acc = mp.getAddress(acc)
-		if acc == nil {
-			return types.ErrTxInvalidAccount
-		}
+	if tx.HasVerifedAccount() {
+		acc = tx.GetVerifedAccount()
 	}
 
 	mp.Lock()
@@ -442,6 +439,9 @@ func (mp *MemPool) verifyTx(tx *types.Tx) error {
 		err = key.VerifyTxWithAddress(tx, account)
 		if err != nil {
 			return err
+		}
+		if !tx.SetVerifedAccount(account) {
+			mp.Warn().Str("account", string(account)).Msg("could not set verifed account")
 		}
 	}
 	return nil

--- a/types/blockchain.go
+++ b/types/blockchain.go
@@ -445,6 +445,7 @@ func (tx *Tx) CalculateTxHash() []byte {
 	txBody := tx.Body
 	digest := sha256.New()
 	binary.Write(digest, binary.LittleEndian, txBody.Nonce)
+
 	digest.Write(txBody.Account)
 	digest.Write(txBody.Recipient)
 	digest.Write(txBody.Amount)
@@ -544,6 +545,34 @@ func (tx *Tx) ValidateWithContractState(contractState *State) error {
 	//in system.ValidateSystemTx
 	//in name.ValidateNameTx
 	return nil
+}
+
+func (tx *Tx) SetVerifedAccount(account []byte) bool {
+	if len(account) != AddressLength {
+		return false
+	}
+	tx.Body.Account = append(account, tx.GetBody().GetAccount()...)
+	return true
+}
+
+func (tx *Tx) GetVerifedAccount() []byte {
+	account := tx.GetBody().GetAccount()
+	if len(account) > AddressLength {
+		return account[:AddressLength]
+	}
+	return nil
+}
+
+func (tx *Tx) HasVerifedAccount() bool {
+	return len(tx.GetBody().GetAccount()) > AddressLength
+}
+
+func (tx *Tx) RemoveVerifedAccount() bool {
+	if len(tx.Body.Account) < AddressLength {
+		return false
+	}
+	tx.Body.Account = tx.GetBody().GetAccount()[AddressLength:]
+	return true
 }
 
 func (tx *Tx) NeedNameVerify() bool {


### PR DESCRIPTION
To validate transactions in parallel in a block, transactions that create or update names are effective after they are mined and entered the block. Therefore, if any of the past blocks contain transactions that use the changed name after you rename them, the blocks become invalid and break their backward compatibility.

블록 안에 트랜잭션을 병렬적으로 검증하기 위해서, 이름을 만들거나 변경하는 트랜잭션은 채굴되어 블록에 들어간 이후 부터 효력이 발휘됩니다. 때문에 과거 블록 중에 이름을 변경한 후에 변경된 이름을 이용하는 트랜잭션이 포함된 것이 있다면, 그 블록은 유효하지 않은 블록이 되어 하위 호환성이 깨집니다.