### PR TITLE
Hotfix/0.10 deadlock

### DIFF
--- a/p2p/MockRemotePeer_test.go
+++ b/p2p/MockRemotePeer_test.go
@@ -148,6 +148,19 @@ func (_m *MockRemotePeer) Meta() PeerMeta {
 	return r0
 }
 
+func (_m *MockRemotePeer) ManageNumber() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	return r0
+}
+
 // State provides a mock function with given fields:
 func (_m *MockRemotePeer) State() types.PeerState {
 	ret := _m.Called()

--- a/p2p/handshake.go
+++ b/p2p/handshake.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p-peer"
 )
 
+// HSHandlerFactory is creator of HSHandler
 type HSHandlerFactory interface {
 	CreateHSHandler(outbound bool, pm PeerManager, actor ActorService, log *log.Logger, pid peer.ID) HSHandler
 }

--- a/p2p/mockPeerManager_test.go
+++ b/p2p/mockPeerManager_test.go
@@ -103,7 +103,7 @@ func (_m *MockPeerManager) AddNewPeer(_a0 PeerMeta) {
 }
 
 // RemovePeer provides a mock function with given fields: _a0
-func (_m *MockPeerManager) RemovePeer(_a0 peer.ID) {
+func (_m *MockPeerManager) RemovePeer(_a0 RemotePeer) {
 	_m.Called(_a0)
 }
 

--- a/p2p/peermanager_test.go
+++ b/p2p/peermanager_test.go
@@ -37,7 +37,7 @@ func FailTestGetPeers(t *testing.T) {
 		for i := 0; i < iterSize; i++ {
 			peerID := peer.ID(strconv.Itoa(i))
 			peerMeta := PeerMeta{ID: peerID}
-			target.remotePeers[peerID] = newRemotePeer(peerMeta, target, mockActorServ, logger, nil, nil, nil)
+			target.remotePeers[peerID] = newRemotePeer(peerMeta, target, mockActorServ, logger, nil, nil, nil, nil)
 			if i == (iterSize >> 2) {
 				wg.Done()
 			}
@@ -79,7 +79,7 @@ func TestPeerManager_GetPeers(t *testing.T) {
 		for i := 0; i < iterSize; i++ {
 			peerID := peer.ID(strconv.Itoa(i))
 			peerMeta := PeerMeta{ID: peerID}
-			target.insertPeer(peerID, newRemotePeer(peerMeta, target, mockActorServ, logger, nil, nil,nil))
+			target.insertPeer(peerID, newRemotePeer(peerMeta, target, mockActorServ, logger, nil, nil, nil, nil))
 			if i == (iterSize >> 2) {
 				wg.Done()
 			}

--- a/p2p/peermanager_test.go
+++ b/p2p/peermanager_test.go
@@ -176,15 +176,3 @@ func TestPeerManager_init(t *testing.T) {
 	}
 }
 
-func TestPeerManager_addOutboundPeer(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		// TODO: test cases
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			
-		})
-	}
-}

--- a/p2p/protobufHelper_test.go
+++ b/p2p/protobufHelper_test.go
@@ -35,7 +35,7 @@ func Test_pbRequestOrder_SendTo(t *testing.T) {
 
 			mockRW := new(MockMsgReadWriter)
 			mockRW.On("WriteMsg", mock.Anything).Return(tt.writeErr)
-			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, mockRW)
+			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, nil, mockRW)
 
 			pr := factory.newMsgRequestOrder(true, PingRequest, &types.Ping{})
 			prevCacheSize := len(peer.requests)
@@ -76,7 +76,7 @@ func Test_pbMessageOrder_SendTo(t *testing.T) {
 
 			mockRW := new(MockMsgReadWriter)
 			mockRW.On("WriteMsg", mock.Anything).Return(tt.writeErr)
-			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, mockRW)
+			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, nil, mockRW)
 
 			pr := factory.newMsgResponseOrder(NewMsgID(), PingResponse, &types.Pong{})
 			msgID := pr.GetMsgID()
@@ -118,7 +118,7 @@ func Test_pbBlkNoticeOrder_SendTo(t *testing.T) {
 			mockPeerManager := new(MockPeerManager)
 			mockRW := new(MockMsgReadWriter)
 			mockRW.On("WriteMsg", mock.Anything).Return(tt.writeErr)
-			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, mockRW)
+			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, nil, mockRW)
 
 			target := factory.newMsgBlkBroadcastOrder(&types.NewBlockNotice{BlockHash: dummyBlockHash})
 			msgID := sampleMsgID
@@ -172,7 +172,7 @@ func Test_pbTxNoticeOrder_SendTo(t *testing.T) {
 
 			mockRW := new(MockMsgReadWriter)
 			mockRW.On("WriteMsg", mock.Anything).Return(tt.writeErr)
-			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, mockRW)
+			peer := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, factory, &dummySigner{}, nil, mockRW)
 
 			pr := factory.newMsgTxBroadcastOrder(&types.NewTransactionsNotice{TxHashes: sampleHashes})
 			msgID := pr.GetMsgID()

--- a/p2p/remotepeer.go
+++ b/p2p/remotepeer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aergoio/aergo/message"
 	"github.com/aergoio/aergo/p2p/metric"
 	"github.com/golang/protobuf/proto"
+	"github.com/libp2p/go-libp2p-net"
 	"sync"
 	"time"
 
@@ -29,6 +30,8 @@ func init() {
 type RemotePeer interface {
 	ID() peer.ID
 	Meta() PeerMeta
+	ManageNumber() uint32
+
 	State() types.PeerState
 	LastNotice() *types.NewBlockNotice
 
@@ -48,7 +51,6 @@ type RemotePeer interface {
 	updateBlkCache(hash BlkHash, blkNotice *types.NewBlockNotice) bool
 	// updateTxCache add hashes to transaction cache and return newly added hashes.
 	updateTxCache(hashes []TxHash) []TxHash
-
 
 	// TODO
 	MF() moFactory
@@ -72,6 +74,7 @@ type remotePeerImpl struct {
 	logger       *log.Logger
 	pingDuration time.Duration
 
+	manageNum uint32
 	meta      PeerMeta
 	state     types.PeerState
 	actorServ ActorService
@@ -102,19 +105,20 @@ type remotePeerImpl struct {
 	txNoticeQueue *p2putil.PressableQueue
 	maxTxNoticeHashSize int
 
+	s net.Stream
 	rw MsgReadWriter
 }
 
 var _ RemotePeer = (*remotePeerImpl)(nil)
 
 // newRemotePeer create an object which represent a remote peer.
-func newRemotePeer(meta PeerMeta, pm PeerManager, actor ActorService, log *log.Logger, mf moFactory, signer msgSigner, rw MsgReadWriter) *remotePeerImpl {
+func newRemotePeer(meta PeerMeta, pm PeerManager, actor ActorService, log *log.Logger, mf moFactory, signer msgSigner, s net.Stream, rw MsgReadWriter) *remotePeerImpl {
 	rPeer := &remotePeerImpl{
-		meta: meta, pm: pm, actorServ: actor, logger: log, mf: mf, signer: signer, rw: rw,
+		meta: meta, pm: pm, actorServ: actor, logger: log, mf: mf, signer: signer, s:s, rw: rw,
 		pingDuration: defaultPingInterval,
 		state:        types.STARTING,
 
-		stopChan:   make(chan struct{}),
+		stopChan:   make(chan struct{},1),
 		closeWrite: make(chan struct{}),
 
 		requests:    make(map[MsgID]*requestInfo),
@@ -151,6 +155,10 @@ func (p *remotePeerImpl) Meta() PeerMeta {
 	return p.meta
 }
 
+func (p *remotePeerImpl) ManageNumber() uint32 {
+	return p.manageNum
+}
+
 func (p *remotePeerImpl) MF() moFactory {
 	return p.mf
 }
@@ -158,18 +166,6 @@ func (p *remotePeerImpl) MF() moFactory {
 // State returns current state of peer
 func (p *remotePeerImpl) State() types.PeerState {
 	return p.state.Get()
-}
-
-
-func (p *remotePeerImpl) checkState() error {
-	switch p.State() {
-	case types.HANDSHAKING:
-		return fmt.Errorf("not handshaked")
-	case types.STOPPED:
-		return fmt.Errorf("peer stopped")
-	default:
-		return nil
-	}
 }
 
 
@@ -204,7 +200,6 @@ func (p *remotePeerImpl) runPeer() {
 	go p.runRead()
 
 	txNoticeTicker := time.NewTicker(txNoticeInterval)
-	defer txNoticeTicker.Stop()
 
 	// peer state is changed to RUNNIG after all sub goroutine is ready, and to STOPPED before fll sub goroutine is stopped.
 	p.state.SetAndGet(types.RUNNING)
@@ -220,12 +215,15 @@ READNOPLOOP:
 		}
 	}
 
-	p.logger.Info().Str(LogPeerID, p.meta.ID.Pretty()).Msg("Finishing peer")
-	p.state.SetAndGet(types.STOPPED)
+	p.logger.Info().Uint32("manage_num",p.manageNum).Str(LogPeerID, p.meta.ID.Pretty()).Msg("Finishing peer")
+	txNoticeTicker.Stop()
 	pingTicker.Stop()
 	// finish goroutine write. read goroutine will be closed automatically when disconnect
 	p.closeWrite <- struct{}{}
 	close(p.stopChan)
+	p.state.SetAndGet(types.STOPPED)
+
+	p.pm.RemovePeer(p)
 }
 
 func (p *remotePeerImpl) runWrite() {
@@ -249,24 +247,41 @@ WRITELOOP:
 		}
 	}
 	cleanupTicker.Stop()
+	p.cleanupWrite()
+	p.s.Close()
 
-	// closing channel is to golang runtime
+	// closing channel is up to golang runtime
 	// close(p.write)
 	// close(p.consumeChan)
 }
+
+func (p *remotePeerImpl) cleanupWrite() {
+	// 1. cleaning receive handlers. TODO add code
+
+	// 2. canceling not sent orders TODO add code
+
+	for {
+		select {
+		case m := <-p.dWrite:
+			m.IsRequest()
+		default:
+			return
+		}
+	}
+}
+
 
 func (p *remotePeerImpl) runRead() {
 	for {
 		msg, err := p.rw.ReadMsg()
 		if err != nil {
 			p.logger.Error().Str(LogPeerID, p.ID().Pretty()).Err(err).Msg("Failed to read message")
-			p.pm.RemovePeer(p.ID())
+			p.stop()
 			return
 		}
-
 		if err = p.handleMsg(msg); err != nil {
 			p.logger.Error().Str(LogPeerID, p.ID().Pretty()).Err(err).Msg("Failed to handle message")
-			p.pm.RemovePeer(p.ID())
+			p.stop()
 			return
 		}
 	}
@@ -281,6 +296,11 @@ func (p *remotePeerImpl) handleMsg(msg Message) error {
 			err = fmt.Errorf("internal error")
 		}
 	}()
+
+	if p.State() > types.RUNNING {
+		p.logger.Debug().Str(LogPeerID, p.ID().Pretty()).Str(LogMsgID, msg.ID().String()).Str(LogProtoID, subProto.String()).Str("current_state", p.State().String()).Msg("peer is not running. silently drop input message")
+		return nil
+	}
 
 	handler, found := p.handlers[subProto]
 	if !found {
@@ -309,13 +329,16 @@ func (p *remotePeerImpl) handleMsg(msg Message) error {
 
 // Stop stops aPeer works
 func (p *remotePeerImpl) stop() {
-	p.stopChan <- struct{}{}
+	prevState := p.state.SetAndGet(types.STOPPING)
+	if prevState <= types.RUNNING {
+		p.stopChan <- struct{}{}
+	}
 }
 
 func (p *remotePeerImpl) sendMessage(msg msgOrder) {
-	if p.state.Get() != types.RUNNING {
+	if p.State() > types.RUNNING {
 		p.logger.Debug().Str(LogPeerID, p.meta.ID.Pretty()).Str(LogProtoID, msg.GetProtocolID().String()).
-			Str(LogMsgID, msg.GetMsgID().String()).Interface("peer_state", p.State()).Msg("Cancel sending messge, since peer is not running state")
+			Str(LogMsgID, msg.GetMsgID().String()).Str("current_state", p.State().String()).Msg("Cancel sending messge, since peer is not running state")
 		return
 	}
 	select {
@@ -324,14 +347,15 @@ func (p *remotePeerImpl) sendMessage(msg msgOrder) {
 		default:
 			p.logger.Info().Str(LogPeerID, p.meta.ID.Pretty()).Str(LogProtoID, msg.GetProtocolID().String()).
 				Str(LogMsgID, msg.GetMsgID().String()).Msg("Remote peer is busy or down")
-			p.pm.RemovePeer(p.meta.ID)
+			// TODO find more elegant way to handled flooding queue. in lots of cases, pending for dropped tx notice or newblocknotice (not blockproducednotice) are not critical in lots of cases.
+			p.stop()
 	}
 }
 
 func (p *remotePeerImpl) sendAndWaitMessage(msg msgOrder, timeout time.Duration) error {
-	if p.state.Get() != types.RUNNING {
+	if p.State() > types.RUNNING {
 		p.logger.Debug().Str(LogPeerID, p.meta.ID.Pretty()).Str(LogProtoID, msg.GetProtocolID().String()).
-			Str(LogMsgID, msg.GetMsgID().String()).Interface("peer_state", p.State()).Msg("Cancel sending messge, since peer is not running state")
+			Str(LogMsgID, msg.GetMsgID().String()).Str("current_state", p.State().String()).Msg("Cancel sending messge, since peer is not running state")
 		return fmt.Errorf("not running")
 	}
 	select {
@@ -340,7 +364,8 @@ func (p *remotePeerImpl) sendAndWaitMessage(msg msgOrder, timeout time.Duration)
 		case <- time.NewTimer(timeout).C :
 			p.logger.Info().Str(LogPeerID, p.meta.ID.Pretty()).Str(LogProtoID, msg.GetProtocolID().String()).
 				Str(LogMsgID, msg.GetMsgID().String()).Msg("Remote peer is busy or down")
-			p.pm.RemovePeer(p.meta.ID)
+			// TODO find more elegant way to handled flooding queue. in lots of cases, pending for dropped tx notice or newblocknotice (not blockproducednotice) are not critical in lots of cases.
+			p.stop()
 			return TimeoutError
 	}
 }
@@ -353,10 +378,6 @@ func (p *remotePeerImpl) pushTxsNotice(txHashes []TxHash) {
 			p.sendTxNotices()
 			// this Offer is always succeeded by invariant
 			p.txNoticeQueue.Offer(hash)
-			//if !p.txNoticeQueue.Offer(hash) {
-			//	// TODO: temporary check in developement. remove this condition after test successes
-			//	panic("Serious bug occured.")
-			//}
 		}
 	}
 }
@@ -395,7 +416,7 @@ func (p *remotePeerImpl) updateMetaInfo(statusMsg *types.Status) {
 func (p *remotePeerImpl) writeToPeer(m msgOrder) {
 	if err := m.SendTo(p) ; err != nil {
 		// write fail
-		p.pm.RemovePeer(p.ID())
+		p.stop()
 	}
 }
 
@@ -455,8 +476,8 @@ func (p *remotePeerImpl) sendPing() {
 // send notice message and then disconnect. this routine should only run in RunPeer go routine
 func (p *remotePeerImpl) goAwayMsg(msg string) {
 	p.logger.Info().Str(LogPeerID, p.meta.ID.Pretty()).Str("msg", msg).Msg("Peer is closing")
-	p.sendMessage(p.mf.newMsgRequestOrder(false, GoAway, &types.GoAwayNotice{Message: msg}))
-	p.pm.RemovePeer(p.meta.ID)
+	p.sendAndWaitMessage(p.mf.newMsgRequestOrder(false, GoAway, &types.GoAwayNotice{Message: msg}), time.Second)
+	p.stop()
 }
 
 func (p *remotePeerImpl) pruneRequests() {

--- a/p2p/remotepeer_test.go
+++ b/p2p/remotepeer_test.go
@@ -49,8 +49,7 @@ func TestAergoPeer_RunPeer(t *testing.T) {
 	dummyP2PServ := new(MockPeerManager)
 	mockMF := new(MockMoFactory)
 	dummyRW := new(MockMsgReadWriter)
-	target := newRemotePeer(PeerMeta{ID: peer.ID("ddddd")}, dummyP2PServ, mockActorServ,
-		logger, mockMF, nil, dummyRW)
+	target := newRemotePeer(PeerMeta{ID: peer.ID("ddddd")}, dummyP2PServ, mockActorServ, logger, mockMF, nil, nil, dummyRW)
 
 	target.pingDuration = time.Second * 10
 	dummyBestBlock := types.Block{Hash: []byte("testHash"), Header: &types.BlockHeader{BlockNo: 1234}}
@@ -94,6 +93,8 @@ func TestRemotePeer_writeToPeer(t *testing.T) {
 			mockActorServ := new(MockActorService)
 			mockPeerManager := new(MockPeerManager)
 			mockOrder := new(MockMsgOrder)
+			mockStream := new(MockStream)
+			mockStream.On("Close").Return(nil)
 			dummyRW := new(MockMsgReadWriter)
 			mockOrder.On("IsNeedSign").Return(true)
 			mockOrder.On("IsRequest", mockPeerManager).Return(true)
@@ -102,7 +103,7 @@ func TestRemotePeer_writeToPeer(t *testing.T) {
 			mockOrder.On("GetMsgID").Return(sampleMsgID)
 			mockOrder.On("ResponseExpected").Return(tt.args.needResponse)
 
-			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, nil, nil, dummyRW)
+			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, nil, nil, mockStream, dummyRW)
 			p.state.SetAndGet(types.RUNNING)
 			go p.runWrite()
 			p.state.SetAndGet(types.RUNNING)
@@ -118,7 +119,8 @@ func TestRemotePeer_writeToPeer(t *testing.T) {
 	}
 }
 
-func TestePeer_sendPing(t *testing.T) {
+func TestRemotePeer_sendPing(t *testing.T) {
+	t.Skip("Send ping is not used for now, and will be reused after")
 	selfPeerID, _ := peer.IDB58Decode("16Uiu2HAmFqptXPfcdaCdwipB2fhHATgKGVFVPehDAPZsDKSU7jRm")
 	sampleSelf := PeerMeta{ID: selfPeerID, IPAddress: "192.168.1.1", Port: 6845}
 
@@ -143,7 +145,7 @@ func TestePeer_sendPing(t *testing.T) {
 			mockActorServ.On("CallRequest", message.ChainSvc, mock.AnythingOfType("*message.GetBestBlock")).Return(dummyBestBlockRsp, tt.getBlockErr)
 			mockPeerManager.On("SelfMeta").Return(sampleSelf)
 			mockMF.On("signMsg", mock.AnythingOfType("*types.P2PMessage")).Return(nil)
-			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, nil, nil)
+			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, nil, nil, nil)
 			p.state.SetAndGet(types.RUNNING)
 
 			go p.sendPing()
@@ -180,7 +182,10 @@ func TestRemotePeer_pruneRequests(t *testing.T) {
 		// logger.SetLevel(tt.loglevel)
 		mockActorServ := new(MockActorService)
 		mockPeerManager := new(MockPeerManager)
-		p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, nil, nil, nil)
+		mockStream := new(MockStream)
+		mockStream.On("Close").Return(nil)
+
+		p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, nil, nil, mockStream, nil)
 		t.Run(tt.name, func(t *testing.T) {
 			mid1, mid2, midn := NewMsgID(), NewMsgID(), NewMsgID()
 			p.requests[mid1] = &requestInfo{cTime: time.Now().Add(time.Minute * -61), reqMO: &pbRequestOrder{pbMessageOrder{message: &V030Message{id: mid1}}, nil}}
@@ -223,7 +228,7 @@ func TestRemotePeer_sendMessage(t *testing.T) {
 			wg.Add(1)
 			wg2 := &sync.WaitGroup{}
 			wg2.Add(1)
-			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, nil, nil, nil)
+			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, nil, nil, nil, nil)
 			p.state.SetAndGet(types.RUNNING)
 
 			if !tt.timeout {
@@ -303,7 +308,7 @@ func TestRemotePeer_handleMsg(t *testing.T) {
 			mockMsgHandler.On("handle", mock.Anything, mock.Anything)
 			mockSigner.On("verifyMsg", mock.Anything, mock.Anything).Return(nil)
 
-			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil)
+			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil, nil)
 			target.handlers[PingRequest] = mockMsgHandler
 
 			if err := target.handleMsg(msg); (err != nil) != tt.wantErr {
@@ -360,7 +365,7 @@ func TestRemotePeer_sendTxNotices(t *testing.T) {
 
 			mockMF.On("newMsgTxBroadcastOrder", mock.AnythingOfType("*types.NewTransactionsNotice")).Return(mockOrder)
 
-			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil)
+			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil, nil)
 			target.maxTxNoticeHashSize = maxTxHashSize
 
 			for i := 0; i < test.initCnt; i++ {
@@ -397,7 +402,7 @@ func TestRemotePeerImpl_UpdateBlkCache(t *testing.T) {
 			mockSigner := new(mockMsgSigner)
 			mockMF := new(MockMoFactory)
 
-			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil)
+			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil, nil)
 			for _, hash := range test.inCache {
 				target.blkHashCache.Add(hash, true)
 			}
@@ -430,7 +435,7 @@ func TestRemotePeerImpl_UpdateTxCache(t *testing.T) {
 			mockSigner := new(mockMsgSigner)
 			mockMF := new(MockMoFactory)
 
-			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil)
+			target := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil, nil)
 			for _, hash := range test.inCache {
 				target.txHashCache.Add(hash, true)
 			}
@@ -474,7 +479,7 @@ func TestRemotePeerImpl_pushTxsNotice(t *testing.T) {
 
 			mockMF.On("newMsgTxBroadcastOrder", mock.AnythingOfType("*types.NewTransactionsNotice")).Return(mockMO)
 
-			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil)
+			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil, nil)
 			p.txNoticeQueue = p2putil.NewPressableQueue(maxTxHashSize)
 			p.maxTxNoticeHashSize = maxTxHashSize
 			//p.write.Open()
@@ -521,7 +526,7 @@ func TestRemotePeerImpl_GetReceiver(t *testing.T) {
 			mockPeerManager := new(MockPeerManager)
 			mockSigner := new(mockMsgSigner)
 			mockMF := new(MockMoFactory)
-			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil)
+			p := newRemotePeer(sampleMeta, mockPeerManager, mockActorServ, logger, mockMF, mockSigner, nil, nil)
 			for _, add := range test.toAdd {
 				p.requests[add] = &requestInfo{receiver: recvList[add]}
 			}

--- a/p2p/subprotocoltx_test.go
+++ b/p2p/subprotocoltx_test.go
@@ -179,7 +179,7 @@ func TestTxRequestHandler_handle(t *testing.T) {
 			mockActor := new(MockActorService)
 			mockRW := new(MockMsgReadWriter)
 			mockMF := new(MockMoFactory)
-			dummyPeer := newRemotePeer(dummyMeta, mockPM, mockActor, logger, mockMF, &dummySigner{}, mockRW)
+			dummyPeer := newRemotePeer(dummyMeta, mockPM, mockActor, logger, mockMF, &dummySigner{}, nil, mockRW)
 			mockMsgHelper := new(mocks.Helper)
 
 			header, body := test.setup(t, mockPM, mockActor, mockMsgHelper, mockMF, mockRW)

--- a/types/p2pmore.go
+++ b/types/p2pmore.go
@@ -12,6 +12,10 @@ import (
 	"github.com/libp2p/go-libp2p-peer"
 )
 
+type ResponseMessage interface {
+	GetStatus() ResultStatus
+}
+
 // AddressesToStringMap make map of string for logging or json encoding
 func AddressesToStringMap(addrs []*PeerAddress) []map[string]string {
 	arr := make([]map[string]string, len(addrs))

--- a/types/peerstate.go
+++ b/types/peerstate.go
@@ -13,10 +13,12 @@ const (
 	HANDSHAKING
 	// RUNNING means complete handshake (i.e. exchanged status message) and can communicate each other
 	RUNNING
+	// STOPPING means peer was received stop signal and working in termination process. No new message is sent and receiving message is ignored.
+	STOPPING
+	// STOPPED means peer was tatally finished.
+	STOPPED
 	// DOWN means server can't communicate to remote peer. peer will be delete after TTL or
 	DOWN
-	// STOPPED is totally finished peer, and maybe local server is shutting down.
-	STOPPED
 )
 
 // Get returns current state with concurrent manner
@@ -27,10 +29,6 @@ func (s *PeerState) Get() PeerState {
 // SetAndGet change state in atomic manner
 func (s *PeerState) SetAndGet(ns PeerState) PeerState {
 	return PeerState(atomic.SwapInt32((*int32)(s), int32(ns)))
-}
-
-func (s *PeerState) IncreaseAndGet() PeerState {
-	return PeerState(atomic.AddInt32((*int32)(s), 1))
 }
 
 //go:generate stringer -type=PeerState

--- a/types/peerstate_string.go
+++ b/types/peerstate_string.go
@@ -4,9 +4,9 @@ package types
 
 import "strconv"
 
-const _PeerState_name = "STARTINGHANDSHAKINGRUNNINGDOWNSTOPPED"
+const _PeerState_name = "STARTINGHANDSHAKINGRUNNINGSTOPPINGSTOPPEDDOWN"
 
-var _PeerState_index = [...]uint8{0, 8, 19, 26, 30, 37}
+var _PeerState_index = [...]uint8{0, 8, 19, 26, 34, 41, 45}
 
 func (i PeerState) String() string {
 	if i < 0 || i >= PeerState(len(_PeerState_index)-1) {


### PR DESCRIPTION
Sorry for not written in English

기존에 피어목록을 갱신(추가,삭제) 하는 것이 채널을 사용해 하나씩 동기화 처리 방식으로 했는데, 개별 피어의 기본 동작용 고루틴과 피어매니저의 관리자 고루틴 사에 채널로 넘기는 부분에서 순환 데드락 같은 현상이 발생하면서 p2p전체의 동작도 멈추게 되는 사태가 발생했었습니다. 

이 부분을 피어 동작을 멈추고 매니저에서 삭제하는 부분을 비동기 처리로 바꾸고 삭제하는 것을 채널로 일렬화시키는 게 없어도 될 걸로 보여 해당 부분 채널을 삭제하였습니다. 

자체 테스트는 했지만 실제 문제가 발생한 tx과다유입으로 그래서 피어가 반강제로 접속을 끊으면서 데드락이 발생하는 증상은 직접 재연테스트가 어려워서 이 부분 테스트를 마치고 커밋을 병합하면 좋겠습니다.