### PR TITLE
[P2P] Change behavior of initializing private key

### DIFF
--- a/p2p/internalconst.go
+++ b/p2p/internalconst.go
@@ -63,4 +63,11 @@ const (
 	cachePlaceHolder = true
 )
 
-
+// constants about private key
+const (
+	DefaultPkKeyDirectory = ".aergo"
+	DefaultPkKeyPrefix    = "aergo-peer"
+	DefaultPkKeyExt    = ".key"
+	DefaultPubKeyExt    = ".pub"
+	DefaultPeerIDExt    = ".id"
+)


### PR DESCRIPTION
- Show more accurate error message when specified pk file does not
exist or is not a valid private key file.
- Make and save to default key file when no pk file is specified
and reuse after reboot, to make continuity.
- Generated file location: ${USER_HOME}/.aergo/aergo-peer.key