### PR TITLE
[MISC] Remove REST port from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ MVP based, Forward compatibility, Iteration
 |-------|------|
 |  gRPC | 7845 |
 |  P2P  | 7846 |
-|  REST | 8080 |
 
 ## Installation
 


### PR DESCRIPTION
- REST is not supported now.

- And maybe this patch should be cherry-picked (or applied to anyway) to master branch.