### PR TITLE
[CHAIN] fix reorg bug & refactoring

### DIFF
--- a/chain/chainservice_test.go
+++ b/chain/chainservice_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/config"
 	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/state"
@@ -41,7 +40,7 @@ func (stubC *StubConsensus) IsBlockValid(block *types.Block, bestBlock *types.Bl
 func (stubC *StubConsensus) Update(block *types.Block) {
 
 }
-func (stubC *StubConsensus) Save(tx db.Transaction) error {
+func (stubC *StubConsensus) Save(tx consensus.TxWriter) error {
 	return nil
 }
 func (stubC *StubConsensus) NeedReorganization(rootNo types.BlockNo) bool {

--- a/chain/reorg.go
+++ b/chain/reorg.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/aergoio/aergo/state"
 
-	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/internal/enc"
 	"github.com/aergoio/aergo/message"
@@ -307,9 +306,9 @@ func (reorg *reorganizer) swapTxMapping() error {
 		}
 
 		dbTx := cs.cdb.store.NewTx()
-		defer dbTx.Discard()
 
 		if err := cdb.addTxsOfBlock(&dbTx, newBlock.GetBody().GetTxs(), newBlock.BlockHash()); err != nil {
+			dbTx.Discard()
 			return err
 		}
 
@@ -317,25 +316,14 @@ func (reorg *reorganizer) swapTxMapping() error {
 	}
 
 	// delete old tx mapping
-	txCnt := 0
-	var dbTx db.Transaction
+	bulk := cdb.store.NewBulk()
+	defer bulk.DiscardLast()
 
 	for _, oldTx := range oldTxs {
-		if dbTx == nil {
-			dbTx = cs.cdb.store.NewTx()
-		}
-		defer dbTx.Discard()
-
-		cdb.deleteTx(&dbTx, oldTx)
-
-		txCnt++
-
-		if txCnt >= TxBatchMax {
-			dbTx.Commit()
-			dbTx = nil
-			txCnt = 0
-		}
+		bulk.Delete(oldTx.Hash)
 	}
+
+	bulk.Flush()
 
 	//add rollbacked Tx to mempool (except played tx in roll forward)
 	count := len(oldTxs)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -95,9 +95,13 @@ type ChainConsensus interface {
 	VerifySign(block *types.Block) error
 	IsBlockValid(block *types.Block, bestBlock *types.Block) error
 	Update(block *types.Block)
-	Save(tx db.Transaction) error
+	Save(tx TxWriter) error
 	NeedReorganization(rootNo types.BlockNo) bool
 	Info() string
+}
+
+type TxWriter interface {
+	Set(key, value []byte)
 }
 
 // Info represents an information for a consensus implementation.

--- a/consensus/impl/dpos/lib.go
+++ b/consensus/impl/dpos/lib.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/aergoio/aergo-lib/db"
+	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/internal/common"
 	"github.com/aergoio/aergo/p2p"
 	"github.com/aergoio/aergo/types"
@@ -211,7 +212,7 @@ func (ls *libStatus) load(endBlockNo types.BlockNo) {
 	}
 }
 
-func (ls *libStatus) save(tx db.Transaction) error {
+func (ls *libStatus) save(tx consensus.TxWriter) error {
 	b, err := common.GobEncode(ls)
 	if err != nil {
 		return err

--- a/consensus/impl/dpos/status.go
+++ b/consensus/impl/dpos/status.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/consensus/impl/dpos/bp"
 	"github.com/aergoio/aergo/state"
@@ -148,7 +147,7 @@ func (s *Status) updateLIB(lib *blockInfo) {
 }
 
 // Save saves the consensus status information for the later recovery.
-func (s *Status) Save(tx db.Transaction) error {
+func (s *Status) Save(tx consensus.TxWriter) error {
 	s.Lock()
 	defer s.Unlock()
 

--- a/consensus/impl/raft/blockfactory.go
+++ b/consensus/impl/raft/blockfactory.go
@@ -9,9 +9,8 @@ import (
 
 	"github.com/aergoio/aergo/internal/enc"
 	"github.com/aergoio/aergo/p2p"
-	crypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/libp2p/go-libp2p-crypto"
 
-	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo-lib/log"
 	bc "github.com/aergoio/aergo/chain"
 	"github.com/aergoio/aergo/config"
@@ -224,7 +223,7 @@ func (bf *BlockFactory) Update(block *types.Block) {
 }
 
 // Save has nothging to do.
-func (bf *BlockFactory) Save(tx db.Transaction) error {
+func (bf *BlockFactory) Save(tx consensus.TxWriter) error {
 	return nil
 }
 

--- a/consensus/impl/sbp/sbp.go
+++ b/consensus/impl/sbp/sbp.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo-lib/log"
 	bc "github.com/aergoio/aergo/chain"
 	"github.com/aergoio/aergo/config"
@@ -154,7 +153,7 @@ func (s *SimpleBlockFactory) Update(block *types.Block) {
 }
 
 // Save has nothging to do.
-func (s *SimpleBlockFactory) Save(tx db.Transaction) error {
+func (s *SimpleBlockFactory) Save(tx consensus.TxWriter) error {
 	return nil
 }
 


### PR DESCRIPTION
1. fix bug where old tx mapping could not committed when swapping tx mapping.
    old txs has saved in transaction but not commited if tx count < 10000.
    but when rpc is called, tx mapping info is dropped if block of tx isn't included in chain 
2. refactoring - apply bulk transaction when swapping chain info during reorg