### PR TITLE
[brick] Ensure hello.brick has enough account balance to run

### DIFF
--- a/cmd/brick/example/hello.brick
+++ b/cmd/brick/example/hello.brick
@@ -1,5 +1,5 @@
 # create an account and deposit coin
-inject bj 100
+inject bj 10000000000
 
 # check balance
 getstate bj


### PR DESCRIPTION
hello.brick was failing with:

      ERR execution fail error="not enough balance" cmd=deploy module=brick
    example/hello.brick:8 deploy bj 0 helloctr `./example/hello.lua`

so increase the balance provided.