### PR TITLE
Ensure aergoluac has a non-zero exit code on error

### DIFF
--- a/cmd/aergoluac/main.go
+++ b/cmd/aergoluac/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/aergoio/aergo/cmd/aergoluac/util"
@@ -47,10 +46,7 @@ func init() {
 				}
 				err = util.CompileFromFile(args[0], args[1], abiFile)
 			}
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Error:", err)
-			}
-			return nil
+			return err
 		},
 	}
 	rootCmd.PersistentFlags().StringVarP(&abiFile, "abi", "a", "", "abi filename")


### PR DESCRIPTION
Always return non-zero exit code on error for consistency.  This ensures that if `aergoluac` is called from within shell scripts / Makefiles etc., errors can be properly detected and handled.

Returning the error from the `cobra.Command` closure automatically causes it to be output to `STDERR`, so we don't need to print it ourselves.