### PR TITLE
Fix build to expect libgmp in libtool/lib64 (#108)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Gopkg.lock
 # python cache
 venv
 __pycache__
+/libtool/lib64/

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -10,7 +10,7 @@ package contract
 #cgo !windows CFLAGS: -DLJ_TARGET_POSIX
 #cgo darwin LDFLAGS: ${SRCDIR}/../libtool/lib/libluajit-5.1.a ${SRCDIR}/../libtool/lib/libgmp.dylib -lm
 #cgo windows LDFLAGS: ${SRCDIR}/../libtool/lib/libluajit-5.1.a ${SRCDIR}/../libtool/bin/libgmp-10.dll -lm
-#cgo !darwin,!windows LDFLAGS: ${SRCDIR}/../libtool/lib/libluajit-5.1.a ${SRCDIR}/../libtool/lib/libgmp.so -lm
+#cgo !darwin,!windows LDFLAGS: ${SRCDIR}/../libtool/lib/libluajit-5.1.a ${SRCDIR}/../libtool/lib64/libgmp.so -lm
 
 
 #include <stdlib.h>


### PR DESCRIPTION
This fixes the build on my Linux machine, but it may break it on others, so someone should review carefully before merging.  As I mentioned in #108, there must be a better approach than this which doesn't require hard-coding this path segment.