### PR TITLE
Make brick use private dummy chain to provide db module (#107)

### DIFF
--- a/cmd/brick/context/context.go
+++ b/cmd/brick/context/context.go
@@ -27,7 +27,7 @@ type context struct {
 }
 
 func Reset() {
-	chain, err := contract.LoadDummyChain(contract.OnPubNet)
+	chain, err := contract.LoadDummyChain()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The `db` module is only supported on non-public networks, so don't configure the dummy chain as a public network.  This may have other negative side-effects I'm not aware of, so please review carefully before merging.

Fixes #107.