### PR TITLE
Ensure brick has a non-zero exit code on error

### DIFF
--- a/cmd/brick/brick.go
+++ b/cmd/brick/brick.go
@@ -110,5 +110,6 @@ func main() {
 		}
 
 		exec.Execute(cmd, args)
+		os.Exit(exec.GetBatchErrorCount())
 	}
 }

--- a/cmd/brick/exec/batch.go
+++ b/cmd/brick/exec/batch.go
@@ -144,6 +144,7 @@ func (c *batch) Run(args string) (string, uint64, []*types.Event, error) {
 		}
 
 		c.level++
+		batchErrorCount = 0
 
 		// set highest log level to turn off verbose
 		if false == verboseBatch {
@@ -196,7 +197,6 @@ func (c *batch) Run(args string) (string, uint64, []*types.Event, error) {
 				fmt.Fprintf(stdOut, "\x1B[31;1mBatch is failed: Error %d\x1B[0m\n", batchErrorCount)
 			}
 			// reset params
-			batchErrorCount = 0
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		}
 
@@ -226,5 +226,8 @@ func (c *batch) Run(args string) (string, uint64, []*types.Event, error) {
 		break
 	}
 
-	return "batch exec is finished", 0, nil, nil
+	if err == nil && batchErrorCount > 0 {
+		err = fmt.Errorf("Batch had %d errors", batchErrorCount)
+	}
+	return "batch exec is finished", 0, nil, err
 }

--- a/cmd/brick/exec/batch.go
+++ b/cmd/brick/exec/batch.go
@@ -144,7 +144,6 @@ func (c *batch) Run(args string) (string, uint64, []*types.Event, error) {
 		}
 
 		c.level++
-		batchErrorCount = 0
 
 		// set highest log level to turn off verbose
 		if false == verboseBatch {
@@ -226,8 +225,5 @@ func (c *batch) Run(args string) (string, uint64, []*types.Event, error) {
 		break
 	}
 
-	if err == nil && batchErrorCount > 0 {
-		err = fmt.Errorf("Batch had %d errors", batchErrorCount)
-	}
-	return "batch exec is finished", 0, nil, err
+	return "batch exec is finished", 0, nil, nil
 }

--- a/cmd/brick/exec/batch.go
+++ b/cmd/brick/exec/batch.go
@@ -19,6 +19,7 @@ var (
 	verboseBatch    = false
 	letBatchKnowErr error
 	batchErrorCount = 0
+	lastBatchErrorCount = 0
 	enableWatch     = false
 	watchFileList   []string
 	watcher         *fsnotify.Watcher
@@ -29,7 +30,7 @@ func EnableVerbose() {
 }
 
 func GetBatchErrorCount() int {
-	return batchErrorCount
+	return lastBatchErrorCount
 }
 
 func EnableWatch() {
@@ -196,6 +197,8 @@ func (c *batch) Run(args string) (string, uint64, []*types.Event, error) {
 				fmt.Fprintf(stdOut, "\x1B[31;1mBatch is failed: Error %d\x1B[0m\n", batchErrorCount)
 			}
 			// reset params
+			lastBatchErrorCount = batchErrorCount
+			batchErrorCount = 0
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		}
 


### PR DESCRIPTION
Always return non-zero exit code on error for consistency.  This ensures that if brick is called from within shell scripts / Makefiles etc., errors can be properly detected and handled.