### PR TITLE
support keystore in aergocli

### DIFF
--- a/cmd/aergocli/cmd/accounts.go
+++ b/cmd/aergocli/cmd/accounts.go
@@ -133,7 +133,7 @@ var listCmd = &cobra.Command{
 			if addresslist != nil {
 				out = out[:len(out)-2]
 			}
-		} else if addrs != nil {
+		} else if addrs != nil && len(addrs) > 0 {
 			for _, a := range addrs {
 				out = fmt.Sprintf("%s\"%s\", ", out, types.EncodeAddress(a))
 			}

--- a/cmd/aergocli/cmd/accounts_test.go
+++ b/cmd/aergocli/cmd/accounts_test.go
@@ -22,7 +22,7 @@ func TestAccountWithPath(t *testing.T) {
 	}()
 
 	// New account
-	outputNew, err := executeCommand(rootCmd, "account", "new", "--password", "1", "--path", testDir)
+	outputNew, err := executeCommand(rootCmd, "account", "new", "--password", "1", "--keystore", testDir)
 	assert.NoError(t, err, "should be success")
 	re := regexp.MustCompile(`\r?\n`)
 	outputNew = re.ReplaceAllString(outputNew, "")
@@ -31,31 +31,31 @@ func TestAccountWithPath(t *testing.T) {
 	assert.Equalf(t, types.AddressLength, len(addr), "wrong address length value = %s", outputNew)
 
 	// List accounts
-	outputList, err := executeCommand(rootCmd, "account", "list", "--path", testDir)
+	outputList, err := executeCommand(rootCmd, "account", "list", "--keystore", testDir)
 	assert.NoError(t, err, "should be success")
 	outputAddress := strings.Split(outputList[2:], "\"]")[0]
 	outputList = re.ReplaceAllString(outputList, "")
 	assert.Equalf(t, len(outputNew)+4, len(outputList), "wrong address list length value = %s", outputList)
 
 	// Export using WIF (legacy)
-	outputExport, err := executeCommand(rootCmd, "account", "export", "--wif", "--address", outputAddress, "--password", "1", "--path", testDir)
+	outputExport, err := executeCommand(rootCmd, "account", "export", "--wif", "--address", outputAddress, "--password", "1", "--keystore", testDir)
 	assert.NoError(t, err, "should be success")
 	importFormat := strings.TrimSpace(outputExport)
 
 	// Import again, should fail (duplicate)
-	outputImport, err := executeCommand(rootCmd, "account", "import", "--if", importFormat, "--password", "1", "--path", testDir)
+	outputImport, err := executeCommand(rootCmd, "account", "import", "--if", importFormat, "--password", "1", "--keystore", testDir)
 	assert.Equalf(t, "already exists\n", outputImport, "should return duplicate = %s", outputImport)
 
 	// Import again in another path, should succeed
-	outputImport, err = executeCommand(rootCmd, "account", "import", "--if", importFormat, "--password", "1", "--path", testDir2)
+	outputImport, err = executeCommand(rootCmd, "account", "import", "--if", importFormat, "--password", "1", "--keystore", testDir2)
 	assert.Equal(t, outputAddress+"\n", outputImport)
 
 	// Export using Keystore
-	outputExportKeystore, err := executeCommand(rootCmd, "account", "export", "--address", outputAddress, "--password", "1", "--path", testDir)
+	outputExportKeystore, err := executeCommand(rootCmd, "account", "export", "--address", outputAddress, "--password", "1", "--keystore", testDir)
 	assert.NoError(t, err, "should be success")
 	keystore := strings.TrimSpace(outputExportKeystore)
 
 	// Import again in another path, should succeed
-	outputImport, err = executeCommand(rootCmd, "account", "import", "--keystore", keystore, "--password", "1", "--path", testDir3)
+	outputImport, err = executeCommand(rootCmd, "account", "import", "--path", keystore, "--password", "1", "--keystore", testDir3)
 	assert.Equal(t, outputAddress+"\n", outputImport)
 }

--- a/cmd/aergocli/cmd/config.go
+++ b/cmd/aergocli/cmd/config.go
@@ -21,9 +21,10 @@ func NewCliContext(homePath string, configFilePath string) *CliContext {
 
 // CliConfig is configs for aergo cli.
 type CliConfig struct {
-	Host string     `mapstructure:"host" description:"Target server host. default is localhost"`
-	Port int        `mapstructure:"port" description:"Target server port. default is 7845"`
-	TLS  *TLSConfig `mapstructure:"tls"`
+	Host         string     `mapstructure:"host" description:"Target server host. default is localhost"`
+	Port         int        `mapstructure:"port" description:"Target server port. default is 7845"`
+	TLS          *TLSConfig `mapstructure:"tls"`
+	KeyStorePath string     `mapstructure:"keystore" description:"Path to keystore directory"`
 }
 
 type TLSConfig struct {
@@ -36,9 +37,10 @@ type TLSConfig struct {
 // GetDefaultConfig return cliconfig with default value. It ALWAYS returns NEW object.
 func (ctx *CliContext) GetDefaultConfig() interface{} {
 	return CliConfig{
-		Host: "localhost",
-		Port: 7845,
-		TLS:  ctx.GetDefaultTLSConfig(),
+		Host:         "localhost",
+		Port:         7845,
+		KeyStorePath: defaultAergoHomePath,
+		TLS:          ctx.GetDefaultTLSConfig(),
 	}
 }
 
@@ -62,6 +64,7 @@ func (ctx *CliContext) GetTemplate() string {
 const configTemplate = `# aergo cli TOML Configuration File (https://github.com/toml-lang/toml)
 host = "{{.Host}}"
 port = "{{.Port}}"
+keystore = "{{.KeyStorePath}}"
 
 [tls]
 servername = "{{.TLS.ServerName}}"

--- a/cmd/aergocli/cmd/name.go
+++ b/cmd/aergocli/cmd/name.go
@@ -37,6 +37,7 @@ func init() {
 	newCmd.Flags().StringVar(&name, "name", "", "Name of account to create")
 	newCmd.MarkFlagRequired("name")
 	newCmd.Flags().StringVar(&spending, "amount", "1aergo", "Spending for create name. at least 1 aergo")
+	newCmd.Flags().StringVar(&pw, "password", "", "Password")
 
 	updateCmd := &cobra.Command{
 		Use:                   "update",
@@ -98,12 +99,7 @@ func execNameNew(cmd *cobra.Command, args []string) error {
 			Type:      types.TxType_GOVERNANCE,
 		},
 	}
-	msg, err := client.SendTX(context.Background(), tx)
-	if err != nil {
-		cmd.Printf("Failed request to aergo sever\n" + err.Error())
-		return nil
-	}
-	cmd.Println(util.JSON(msg))
+	cmd.Println(sendTX(cmd, tx, account))
 	return nil
 }
 
@@ -152,12 +148,8 @@ func execNameUpdate(cmd *cobra.Command, args []string) error {
 			Type:      types.TxType_GOVERNANCE,
 		},
 	}
-	msg, err := client.SendTX(context.Background(), tx)
-	if err != nil {
-		cmd.Printf("Failed request to aergo sever\n" + err.Error())
-		return nil
-	}
-	cmd.Println(util.JSON(msg))
+
+	cmd.Println(sendTX(cmd, tx, account))
 	return nil
 }
 

--- a/cmd/aergocli/cmd/root.go
+++ b/cmd/aergocli/cmd/root.go
@@ -54,10 +54,10 @@ var (
 
 	staking bool
 
-	remote           bool
-	importFormat     string
-	keystoreFilePath string
-	exportAsWif      bool
+	remote         bool
+	importFormat   string
+	importFilePath string
+	exportAsWif    bool
 
 	rootConfig CliConfig
 
@@ -82,6 +82,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&keyFile, "tlskey", "", "client key file for TLS ")
 	rootCmd.PersistentFlags().StringVarP(&host, "host", "H", "localhost", "Host address to aergo server")
 	rootCmd.PersistentFlags().Int32VarP(&port, "port", "p", 7845, "Port number to aergo server")
+	rootCmd.PersistentFlags().StringVar(&dataDir, "keystore", "$HOME/.aergo", "Path to keystore")
 }
 
 func initConfig() {
@@ -92,6 +93,7 @@ func initConfig() {
 	cliCtx.Vc.BindPFlag("tls.cacert", rootCmd.PersistentFlags().Lookup("tlscacert"))
 	cliCtx.Vc.BindPFlag("tls.clientcert", rootCmd.PersistentFlags().Lookup("tlscert"))
 	cliCtx.Vc.BindPFlag("tls.clientkey", rootCmd.PersistentFlags().Lookup("tlskey"))
+	cliCtx.Vc.BindPFlag("keystore", rootCmd.PersistentFlags().Lookup("keystore"))
 
 	cliCtx.BindPFlags(rootCmd.PersistentFlags())
 

--- a/cmd/aergocli/cmd/root.go
+++ b/cmd/aergocli/cmd/root.go
@@ -58,6 +58,7 @@ var (
 	importFormat   string
 	importFilePath string
 	exportAsWif    bool
+	remoteKeystore bool
 
 	rootConfig CliConfig
 
@@ -83,6 +84,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&host, "host", "H", "localhost", "Host address to aergo server")
 	rootCmd.PersistentFlags().Int32VarP(&port, "port", "p", 7845, "Port number to aergo server")
 	rootCmd.PersistentFlags().StringVar(&dataDir, "keystore", "$HOME/.aergo", "Path to keystore")
+	rootCmd.PersistentFlags().BoolVar(&remoteKeystore, "node-keystore", false, "use node keystore")
 }
 
 func initConfig() {
@@ -101,6 +103,9 @@ func initConfig() {
 	err := cliCtx.LoadOrCreateConfig(&rootConfig)
 	if err != nil {
 		log.Fatalf("Fail to load configuration file %v: %v", cliCtx.Vc.ConfigFileUsed(), err)
+	}
+	if remoteKeystore {
+		rootConfig.KeyStorePath = ""
 	}
 }
 

--- a/cmd/aergocli/cmd/sendtx_test.go
+++ b/cmd/aergocli/cmd/sendtx_test.go
@@ -29,7 +29,7 @@ func TestSendTxWithMock(t *testing.T) {
 		nil,
 	).MaxTimes(1)
 
-	output, err := executeCommand(rootCmd, "sendtx", "--from", "AmNL5neKQS2ZwRuBeqfcfHMLg3aSmGoefEh5bW8ozWxrtmxaGHZ3", "--to", "AmNfacq5A3orqn3MhgkHSncufXEP8gVJgqDy8jTgBphXQeuuaHHF", "--amount", "1000")
+	output, err := executeCommand(rootCmd, "sendtx", "--from", "AmNL5neKQS2ZwRuBeqfcfHMLg3aSmGoefEh5bW8ozWxrtmxaGHZ3", "--to", "AmNfacq5A3orqn3MhgkHSncufXEP8gVJgqDy8jTgBphXQeuuaHHF", "--amount", "1000", "--keystore", "")
 	assert.NoError(t, err, "should no error")
 	t.Log(output)
 	out := &types.CommitResult{}
@@ -38,9 +38,9 @@ func TestSendTxWithMock(t *testing.T) {
 }
 
 func TestSendTxFromToValidation(t *testing.T) {
-	_, err := executeCommand(rootCmd, "sendtx", "--from", "InvalidKQS2ZwRuBeqfcfHMLg3aSmGoefEh5bW8ozWxrtmxaGHZ3", "--to", "AmNfacq5A3orqn3MhgkHSncufXEP8gVJgqDy8jTgBphXQeuuaHHF", "--amount", "1000")
+	_, err := executeCommand(rootCmd, "sendtx", "--from", "InvalidKQS2ZwRuBeqfcfHMLg3aSmGoefEh5bW8ozWxrtmxaGHZ3", "--to", "AmNfacq5A3orqn3MhgkHSncufXEP8gVJgqDy8jTgBphXQeuuaHHF", "--amount", "1000", "--keystore", "")
 	assert.Error(t, err, "should error when wrong --from flag")
 
-	_, err = executeCommand(rootCmd, "sendtx", "--from", "AmNL5neKQS2ZwRuBeqfcfHMLg3aSmGoefEh5bW8ozWxrtmxaGHZ3", "--to", "AmNfacq5A3orqn3MhgkHSncufXEP8gVJgqDy8jTgBphXQInvalid", "--amount", "1000")
+	_, err = executeCommand(rootCmd, "sendtx", "--from", "AmNL5neKQS2ZwRuBeqfcfHMLg3aSmGoefEh5bW8ozWxrtmxaGHZ3", "--to", "AmNfacq5A3orqn3MhgkHSncufXEP8gVJgqDy8jTgBphXQInvalid", "--amount", "1000", "--keystore", "")
 	assert.Error(t, err, "should error when wrong --to flag")
 }

--- a/cmd/aergocli/cmd/signtx_test.go
+++ b/cmd/aergocli/cmd/signtx_test.go
@@ -38,7 +38,7 @@ func TestSignWithKey(t *testing.T) {
 func TestSignWithPath(t *testing.T) {
 	const testDir = "signwithpathtest"
 
-	addr, err := executeCommand(rootCmd, "account", "new", "--password", "1", "--path", testDir)
+	addr, err := executeCommand(rootCmd, "account", "new", "--password", "1", "--keystore", testDir)
 	assert.NoError(t, err, "should be success")
 
 	re := regexp.MustCompile(`\r?\n`)
@@ -48,7 +48,7 @@ func TestSignWithPath(t *testing.T) {
 	assert.NoError(t, err, "should be success")
 	assert.Equalf(t, types.AddressLength, len(rawaddr), "wrong address length from %s", addr)
 
-	_, err = executeCommand(rootCmd, "signtx", "--path", testDir, "--jsontx", "{}", "--password", "1", "--address", addr)
+	_, err = executeCommand(rootCmd, "signtx", "--keystore", testDir, "--jsontx", "{}", "--password", "1", "--address", addr)
 	assert.NoError(t, err, "should be success")
 
 	os.RemoveAll(testDir)

--- a/cmd/aergocli/cmd/stake.go
+++ b/cmd/aergocli/cmd/stake.go
@@ -6,10 +6,8 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
-
 	"github.com/aergoio/aergo/cmd/aergocli/util"
 	"github.com/aergoio/aergo/types"
 	"github.com/spf13/cobra"
@@ -65,11 +63,7 @@ func sendStake(cmd *cobra.Command, s bool) error {
 			Type:      types.TxType_GOVERNANCE,
 		},
 	}
-	msg, err := client.SendTX(context.Background(), tx)
-	if err != nil {
-		cmd.Println(err.Error())
-		return nil
-	}
-	cmd.Println(util.JSON(msg))
+
+	cmd.Println(sendTX(cmd, tx, account))
 	return nil
 }

--- a/cmd/aergocli/cmd/stake.go
+++ b/cmd/aergocli/cmd/stake.go
@@ -14,9 +14,10 @@ import (
 )
 
 var stakeCmd = &cobra.Command{
-	Use:   "stake",
-	Short: "Stake balance to aergo system",
-	RunE:  execStake,
+	Use:    "stake",
+	Short:  "Stake balance to aergo system",
+	RunE:   execStake,
+	PreRun: connectAergo,
 }
 
 func execStake(cmd *cobra.Command, args []string) error {
@@ -24,9 +25,10 @@ func execStake(cmd *cobra.Command, args []string) error {
 }
 
 var unstakeCmd = &cobra.Command{
-	Use:   "unstake",
-	Short: "Unstake balance from aergo system",
-	RunE:  execUnstake,
+	Use:    "unstake",
+	Short:  "Unstake balance from aergo system",
+	RunE:   execUnstake,
+	PreRun: connectAergo,
 }
 
 func execUnstake(cmd *cobra.Command, args []string) error {

--- a/cmd/aergocli/cmd/vote.go
+++ b/cmd/aergocli/cmd/vote.go
@@ -33,21 +33,24 @@ func init() {
 }
 
 var voteStatCmd = &cobra.Command{
-	Use:   "votestat",
-	Short: "show voting stat",
-	Run:   execVoteStat,
+	Use:    "votestat",
+	Short:  "show voting stat",
+	Run:    execVoteStat,
+	PreRun: connectAergo,
 }
 
 var voteCmd = &cobra.Command{
-	Use:   "vote",
-	Short: "vote to BPs",
-	Run:   execVote,
+	Use:    "vote",
+	Short:  "vote to BPs",
+	Run:    execVote,
+	PreRun: connectAergo,
 }
 
 var bpCmd = &cobra.Command{
-	Use:   "bp",
-	Short: "show BP list",
-	Run:   execBP,
+	Use:    "bp",
+	Short:  "show BP list",
+	Run:    execBP,
+	PreRun: connectAergo,
 }
 
 const PeerIDLength = 39

--- a/cmd/aergocli/cmd/vote.go
+++ b/cmd/aergocli/cmd/vote.go
@@ -116,13 +116,8 @@ func execVote(cmd *cobra.Command, args []string) {
 			Type:      types.TxType_GOVERNANCE,
 		},
 	}
-	//TODO : support local
-	msg, err := client.SendTX(context.Background(), tx)
-	if err != nil {
-		cmd.Printf("Failed: %s\n", err.Error())
-		return
-	}
-	cmd.Println(util.JSON(msg))
+
+	cmd.Println(sendTX(cmd, tx, account))
 }
 
 func execVoteStat(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This allows local keystore to be used with all account commands (incl sendtx etc).

BREAKING CHANGE
- The new default behavior is to use a local keystore at `$HOME/.aergo`
- You can change the keystore directory by supplying `--keystore /path/to/keystore/`
- To restore the old behavior (using a server provided keystore), pass `--node-keystore`

Remote keystore functionality will be removed in future versions. The reason is that this is prone to unsafe misuse - if used with a publicly accessible node, this can expose user information to the public.