### PR TITLE
[cli] Clarify command line usage. Fixes #121

### DIFF
--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"strconv"
 
 	"github.com/aergoio/aergo/cmd/aergocli/util"
@@ -148,8 +147,8 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 	var payload []byte
 	if len(data) == 0 {
 		if len(args) < 3 {
-			cmd.Usage()
-			os.Exit(1)
+			cmd.SilenceUsage = false
+			return errors.New("not enough arguments")
 		}
 		code, err = ioutil.ReadFile(args[1])
 		if err != nil {

--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -91,9 +91,9 @@ func init() {
 		DisableFlagsInUseLine: true,
 	}
 	deployCmd.PersistentFlags().StringVar(&data, "payload", "", "result of compiling a contract")
-	deployCmd.PersistentFlags().StringVar(&amount, "amount", "0", "setting amount")
+	deployCmd.PersistentFlags().StringVar(&amount, "amount", "0", "amount of token to send with deployment, in aer")
 	deployCmd.PersistentFlags().StringVarP(&contractID, "redeploy", "r", "", "redeploy the contract")
-	deployCmd.Flags().StringVar(&pw, "password", "", "Password")
+	deployCmd.Flags().StringVar(&pw, "password", "", "password (optional, will be asked on the terminal if not given)")
 
 	callCmd := &cobra.Command{
 		Use: `call [flags] <sender> <contract> <funcname> [args]
@@ -106,10 +106,10 @@ func init() {
 	callCmd.PersistentFlags().Uint64Var(&nonce, "nonce", 0, "manually set a nonce (default: set nonce automatically)")
 	callCmd.PersistentFlags().StringVar(&amount, "amount", "0", "amount of token to send with call, in aer")
 	callCmd.PersistentFlags().StringVar(&chainIdHash, "chainidhash", "", "chain id hash value encoded by base58")
-	callCmd.PersistentFlags().BoolVar(&toJson, "tojson", false, "get jsontx")
+	callCmd.PersistentFlags().BoolVar(&toJson, "tojson", false, "display json transaction instead of sending to blockchain")
 	callCmd.PersistentFlags().BoolVar(&gover, "governance", false, "setting type")
-	callCmd.PersistentFlags().BoolVar(&feeDelegation, "delegation", false, "fee dellegation")
-	callCmd.Flags().StringVar(&pw, "password", "", "Password")
+	callCmd.PersistentFlags().BoolVar(&feeDelegation, "delegation", false, "request fee delegation to contract")
+	callCmd.Flags().StringVar(&pw, "password", "", "password (optional, will be asked on the terminal if not given)")
 
 	stateQueryCmd := &cobra.Command{
 		Use:   "statequery [flags] contract <varname> <varindex>",

--- a/cmd/aergocli/cmd/sendtx.go
+++ b/cmd/aergocli/cmd/sendtx.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"context"
 	"errors"
+
 	"github.com/aergoio/aergo/cmd/aergocli/util"
 	"github.com/aergoio/aergo/types"
 	"github.com/mr-tron/base58"
@@ -91,19 +92,19 @@ func sendTX(cmd *cobra.Command, tx *types.Tx, account []byte) string {
 			tx.GetBody().Nonce = state.GetNonce() + 1
 		}
 		if errStr := fillSign(tx, rootConfig.KeyStorePath, pw, account); errStr != "" {
-			return "Error to sign:" + errStr
+			return "Failed to sign: " + errStr
 		}
 		txs := []*types.Tx{tx}
 		var msgs *types.CommitResultList
 		msgs, err = client.CommitTX(context.Background(), &types.TxList{Txs: txs})
 		if err != nil {
-			return "Failed request to aergo server\n" + err.Error()
+			return "Failed request to aergo server: " + err.Error()
 		}
 		return util.JSON(msgs)
 	} else {
 		msg, err := client.SendTX(context.Background(), tx)
 		if err != nil {
-			return "Failed request to aergo sever\n" + err.Error()
+			return "Failed request to aergo sever: " + err.Error()
 		}
 		return util.JSON(msg)
 	}

--- a/types/blockchain.go
+++ b/types/blockchain.go
@@ -692,3 +692,13 @@ func NewBlockHeaderInfoFromPrevBlock(prev *Block, ts int64, bv BlockVersionner) 
 func (b *BlockHeaderInfo) ChainIdHash() []byte {
 	return common.Hasher(b.ChainId)
 }
+
+// HasFunction returns if a function with the given name exists in the ABI definition
+func (abi *ABI) HasFunction(name string) bool {
+	for _, fn := range abi.Functions {
+		if fn.GetName() == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Improved Usage and Error messages
- Cleaned up code

New usage messages:

```
$ aergocli contract deploy
Error: requires exactly 1, 2, 3 or 4 args but received 0
Usage:
  aergocli contract deploy [flags] --payload 'payload string' <creatorAddress> [args]
  aergocli contract deploy [flags] <creatorAddress> <bcfile> <abifile> [args]

  You can pass constructor arguments by passing a JSON string as the optional final parameter, e.g. "[1, 2, 3]".

Flags:
      --amount string     amount of token to send with deployment, in aer (default "0")
  -h, --help              help for deploy
      --password string   password (optional, will be asked on the terminal if not given)
      --payload string    result of compiling a contract
  -r, --redeploy string   redeploy the contract
```

```
$ aergocli contract call
Error: requires exactly 3 or 4 args but received 0
Usage:
  aergocli contract call [flags] <sender> <contract> <funcname> [args]

  You can pass function arguments by passing a JSON string as the optional final parameter, e.g. "[1, 2, 3]".

Flags:
      --amount string        amount of token to send with call, in aer (default "0")
      --chainidhash string   chain id hash value encoded by base58
      --delegation           request fee delegation to contract
      --governance           setting type
  -h, --help                 help for call
      --nonce uint           manually set a nonce (default: set nonce automatically)
      --password string      password (optional, will be asked on the terminal if not given)
      --tojson               display json transaction instead of sending to blockchain
```