### PR TITLE
add to show address even if fail to import account

### DIFF
--- a/account/key/store.go
+++ b/account/key/store.go
@@ -77,7 +77,12 @@ func (ks *Store) ImportKey(imported []byte, oldpass string, newpass string) (Ide
 		return nil, err
 	}
 	privkey, _ := btcec.PrivKeyFromBytes(btcec.S256(), key)
-	return ks.addKey(privkey, newpass)
+	idendity, err := ks.addKey(privkey, newpass)
+	if err != nil {
+		address := crypto.GenerateAddress(&privkey.PublicKey)
+		return address, err
+	}
+	return idendity, nil
 }
 
 // ExportKey is to export encrypted key

--- a/cmd/aergocli/cmd/accounts.go
+++ b/cmd/aergocli/cmd/accounts.go
@@ -212,17 +212,17 @@ func importWif(cmd *cobra.Command) ([]byte, error) {
 
 	if rootConfig.KeyStorePath == "" {
 		msg, errRemote := client.ImportAccount(context.Background(), wif)
-		if errRemote != nil {
-			return nil, fmt.Errorf("node request returned error: %s", errRemote.Error())
-		}
 		address = msg.GetAddress()
+		if errRemote != nil {
+			return address, fmt.Errorf("node request returned error: %s", errRemote.Error())
+		}
 	} else {
 		dataEnvPath := os.ExpandEnv(rootConfig.KeyStorePath)
 		ks := key.NewStore(dataEnvPath, 0)
 		defer ks.CloseStore()
 		address, err = ks.ImportKey(importBuf, wif.Oldpass, wif.Newpass)
 		if err != nil {
-			return nil, err
+			return address, err
 		}
 	}
 	return address, nil
@@ -293,9 +293,11 @@ var importCmd = &cobra.Command{
 		} else {
 			cmd.Help()
 		}
+
 		if err != nil {
 			cmd.PrintErrln(err)
-		} else {
+		}
+		if address != nil {
 			cmd.Println(types.EncodeAddress(address))
 		}
 	},

--- a/cmd/aergocli/cmd/accounts_test.go
+++ b/cmd/aergocli/cmd/accounts_test.go
@@ -44,7 +44,7 @@ func TestAccountWithPath(t *testing.T) {
 
 	// Import again, should fail (duplicate)
 	outputImport, err := executeCommand(rootCmd, "account", "import", "--if", importFormat, "--password", "1", "--keystore", testDir)
-	assert.Equalf(t, "already exists\n", outputImport, "should return duplicate = %s", outputImport)
+	assert.Contains(t, outputImport, "already exists", "should return duplicate = %s", outputImport)
 
 	// Import again in another path, should succeed
 	outputImport, err = executeCommand(rootCmd, "account", "import", "--if", importFormat, "--password", "1", "--keystore", testDir2)


### PR DESCRIPTION
When to import an account, if the same account exists already, `aergocli` shows only `already exist` message.

However, if `aergocli` shows the error with the address, it would be helpful to make an automated script or else.
