### PR TITLE
Store contract code just once

### DIFF
--- a/state/contract.go
+++ b/state/contract.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"math/big"
+	"bytes"
 
 	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/internal/common"
@@ -76,7 +77,10 @@ func (st *ContractState) GetBalance() *big.Int {
 
 func (st *ContractState) SetCode(code []byte) error {
 	codeHash := common.Hasher(code)
-	err := st.SetRawKV(codeHash[:], code)
+	storedCode, err := st.GetRawKV(codeHash[:])
+	if err == nil && !bytes.Equal(code, storedCode) {
+		err = st.SetRawKV(codeHash[:], code)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Copies of the same smart contract should be stored in a single place, to reduce the space used.

Some of new contracts can reach thousands of instances, all of them with exactly the same code