### PR TITLE
brick: multi-line commands on batch mode

### DIFF
--- a/cmd/brick/context/util.go
+++ b/cmd/brick/context/util.go
@@ -68,22 +68,27 @@ func IsCompleteCommand(line string, line_no int, isOpen bool) (bool,error) {
 	chunks := strings.Fields(line)
 
 	for _,chunk := range chunks {
-		if strings.HasPrefix(chunk, "`") {
-			if isOpen {
+		if isOpen {
+			if chunk == "`" {
+				isOpen = false
+			} else if strings.HasPrefix(chunk, "`") {
 				return false, fmt.Errorf("already open parameter at line %v", line_no)
+			} else if strings.HasSuffix(chunk, "`") {
+				isOpen = false
 			}
-			if strings.Count(chunk, "`") > 1 && strings.HasSuffix(chunk, "`") {
-				// for example `keyword`
-			} else {
-				// for example `white space`
+		} else {
+			if chunk == "`" {
 				isOpen = true
-			}
-		} else if strings.HasSuffix(chunk, "`") {
-			if !isOpen {
+			} else if strings.HasPrefix(chunk, "`") {
+				if strings.HasSuffix(chunk, "`") {
+					// for example `keyword`
+				} else {
+					// for example `white space`
+					isOpen = true
+				}
+			} else if strings.HasSuffix(chunk, "`") {
 				return false, fmt.Errorf("closing not open parameter at line %v", line_no)
 			}
-			// end of statement
-			isOpen = false
 		}
 	}
 

--- a/cmd/brick/context/util.go
+++ b/cmd/brick/context/util.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"strings"
+	"fmt"
 )
 
 func ParseFirstWord(input string) (string, string) {
@@ -60,4 +61,31 @@ func SplitSpaceAndAccent(input string, addLastInComplete bool) []Chunk {
 	}
 
 	return ret
+}
+
+func IsCompleteCommand(line string, line_no int, isOpen bool) (bool,error) {
+
+	chunks := strings.Fields(line)
+
+	for _,chunk := range chunks {
+		if strings.HasPrefix(chunk, "`") {
+			if isOpen {
+				return false, fmt.Errorf("already open parameter at line %v", line_no)
+			}
+			if strings.Count(chunk, "`") > 1 && strings.HasSuffix(chunk, "`") {
+				// for example `keyword`
+			} else {
+				// for example `white space`
+				isOpen = true
+			}
+		} else if strings.HasSuffix(chunk, "`") {
+			if !isOpen {
+				return false, fmt.Errorf("closing not open parameter at line %v", line_no)
+			}
+			// end of statement
+			isOpen = false
+		}
+	}
+
+	return isOpen, nil
 }

--- a/cmd/brick/exec/batch.go
+++ b/cmd/brick/exec/batch.go
@@ -97,13 +97,26 @@ func (c *batch) readBatchFile(batchFilePath string) ([]string, error) {
 	}
 	defer batchFile.Close()
 
-	var cmdLines []string
+	var commands []string
+	var command string
+	var line_no int = 0
+	var isOpen bool = false
 	scanner := bufio.NewScanner(batchFile)
 	for scanner.Scan() {
-		cmdLines = append(cmdLines, scanner.Text())
+		line := scanner.Text()
+		line_no += 1
+		command += line
+		isOpen, err = context.IsCompleteCommand(line, line_no, isOpen)
+		if err != nil {
+			return nil, err
+		}
+		if !isOpen {
+			commands = append(commands, command)
+			command = ""
+		}
 	}
 
-	return cmdLines, nil
+	return commands, nil
 }
 
 func (c *batch) parse(args string) (string, error) {

--- a/cmd/brick/exec/batch.go
+++ b/cmd/brick/exec/batch.go
@@ -106,9 +106,11 @@ func (c *batch) readBatchFile(batchFilePath string) ([]string, error) {
 		line := scanner.Text()
 		line_no += 1
 		command += line
-		isOpen, err = context.IsCompleteCommand(line, line_no, isOpen)
-		if err != nil {
-			return nil, err
+		if len(line) > 0 && line[0:1] != "#" {
+			isOpen, err = context.IsCompleteCommand(line, line_no, isOpen)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if !isOpen {
 			commands = append(commands, command)


### PR DESCRIPTION
These changes add support for multi-line commands on batch files

The commands can be break into many lines when inside back-sticks (`)

Example:

```
call ac1 0 contract set_values `[
 123,
 ["first","second","last"],
 ["and another one", true]
]` `"TEST"`
```