### PR TITLE
brick: fix segmentation fault

### DIFF
--- a/contract/vm_dummy.go
+++ b/contract/vm_dummy.go
@@ -658,7 +658,7 @@ func (bc *DummyChain) QueryOnly(contract, queryInfo string, expectedErr string) 
 	if err != nil {
 		return false, "", err
 	}
-	rv, err := Query(strHash(contract), bc.newBState(), nil, cState, []byte(queryInfo))
+	rv, err := Query(strHash(contract), bc.newBState(), bc, cState, []byte(queryInfo))
 
 	if expectedErr != "" {
 		if err == nil {


### PR DESCRIPTION
I am not sure if there is a reason for the `bc` argument to be null in this case.
But this change fixes the problem.

Fixes #138 
Fixes #151 
