### PR TITLE
aergocli: deploy contract in hex format

### DIFF
--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -130,6 +130,11 @@ func init() {
 }
 
 func isHexString(s string) bool {
+  // check is the input has even number of characters
+  if len(s)%2 != 0 {
+    return false
+  }
+  // check if the input contains only hex characters
 	for _, c := range s {
 		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
 			return false

--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -191,7 +191,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 		if isHexString(data) {
 			// the data is expected to be copied from aergoscan view of
 			// the transaction that deployed the contract
-			payload, err = hex.DecodeString(data[2:])
+			payload, err = hex.DecodeString(data)
 		} else {
 			// the data is the output of aergoluac
 			code, err = luacEncoding.DecodeCode(data)


### PR DESCRIPTION
Allow `aergocli` to accept contract code encoded in hex format.

This is used to deploy a copy of an existing contract to another chain, or even the same. Also used for test purposes, when deployed locally.

The data in hex format is copied from aergoscan view of the transaction that deployed the contract.

With this change, the payload given to `aergocli` on `contract deploy` can be either in hex format or the format generated by `aergoluac --payload`