### PR TITLE
add stdint in vm.h

### DIFF
--- a/contract/vm.h
+++ b/contract/vm.h
@@ -5,6 +5,7 @@
 #include <lauxlib.h>
 #include <luajit.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "sqlite3-binding.h"
 
 extern const char *construct_name;


### PR DESCRIPTION
## What is changed?
add stdint.h in vm.h.
window machine cant build aergo because it use mingw compiler.
( mingw don`t know size of uint8_t or uint16_t without import stdint. )


## Is there risk of fork?
unlikely happens.