### PR TITLE
AMAIN-176 Fix block timeout check

### DIFF
--- a/chain/chainhandle.go
+++ b/chain/chainhandle.go
@@ -689,6 +689,7 @@ func (e *blockExecutor) execute() error {
 	}
 
 	if err := e.validatePost(); err != nil {
+		// TODO write verbose tx result if debug log is enabled
 		return err
 	}
 

--- a/chain/chainhandle_test.go
+++ b/chain/chainhandle_test.go
@@ -78,33 +78,33 @@ func TestErrorInExecuteTx(t *testing.T) {
 
 	tx := &types.Tx{}
 
-	err := executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err := executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.EqualError(t, err, types.ErrTxFormatInvalid.Error(), "execute empty tx")
 
 	tx.Body = &types.TxBody{}
 
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.EqualError(t, err, types.ErrTxInvalidChainIdHash.Error(), "execute empty tx body")
 
 	tx.Body.ChainIdHash = common.Hasher(chainID)
 	tx.Body.Account = makeTestAddress(t)
 	tx.Body.Recipient = makeTestAddress(t)
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.EqualError(t, err, types.ErrTxHasInvalidHash.Error(), "execute tx body with account")
 
 	signTestAddress(t, tx)
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.EqualError(t, err, types.ErrTxNonceTooLow.Error(), "execute tx body with account")
 
 	tx.Body.Nonce = 1
 	tx.Body.Amount = new(big.Int).Add(types.StakingMinimum, types.StakingMinimum).Bytes()
 	signTestAddress(t, tx)
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.EqualError(t, err, types.ErrInsufficientBalance.Error(), "execute tx body with nonce")
 
 	tx.Body.Amount = types.MaxAER.Bytes()
 	signTestAddress(t, tx)
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.EqualError(t, err, types.ErrInsufficientBalance.Error(), "execute tx body with nonce")
 }
 
@@ -120,13 +120,13 @@ func TestBasicExecuteTx(t *testing.T) {
 	tx.Body.Recipient = makeTestAddress(t)
 	tx.Body.Nonce = 1
 	signTestAddress(t, tx)
-	err := executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err := executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.NoError(t, err, "execute amount 0")
 
 	tx.Body.Nonce = 2
 	tx.Body.Amount = new(big.Int).SetUint64(1000).Bytes()
 	signTestAddress(t, tx)
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.NoError(t, err, "execute amount 1000")
 
 	tx.Body.Nonce = 3
@@ -136,6 +136,6 @@ func TestBasicExecuteTx(t *testing.T) {
 	tx.Body.Type = types.TxType_GOVERNANCE
 	tx.Body.Payload = []byte(`{"Name":"v1stake"}`)
 	signTestAddress(t, tx)
-	err = executeTx(nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
+	err = executeTx(nil, nil, nil, bs, types.NewTransaction(tx), newTestBlockInfo(chainID), contract.ChainService)
 	assert.NoError(t, err, "execute governance type")
 }

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aergoio/aergo/v2/fee"
 	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/state"
 	"github.com/aergoio/aergo/v2/types"
@@ -635,7 +634,7 @@ func (cm *ChainManager) Receive(context actor.Context) {
 
 		block := msg.Block
 		logger.Debug().Str("hash", block.ID()).Str("prev", block.PrevID()).Uint64("bestno", cm.cdb.getBestBlockNo()).
-			Uint64("no", block.GetHeader().GetBlockNo()).Str("peer", p2putil.ShortForm(msg.PeerID)).Bool("syncer", msg.IsSync).Msg("add block chainservice")
+			Uint64("no", block.GetHeader().GetBlockNo()).Stringer("peer", types.LogPeerShort(msg.PeerID)).Bool("syncer", msg.IsSync).Msg("add block chainservice")
 
 		var bstate *state.BlockState
 		if msg.Bstate != nil {

--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aergoio/aergo/v2/chain"
 	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/state"
 	"github.com/aergoio/aergo/v2/types"
@@ -207,7 +206,7 @@ func ConnectBlock(hs component.ICompSyncRequester, block *types.Block, blockStat
 }
 
 func SyncChain(hs *component.ComponentHub, targetHash []byte, targetNo types.BlockNo, peerID types.PeerID) error {
-	logger.Info().Str("peer", p2putil.ShortForm(peerID)).Uint64("no", targetNo).
+	logger.Info().Stringer("peer", types.LogPeerShort(peerID)).Uint64("no", targetNo).
 		Str("hash", enc.ToString(targetHash)).Msg("request to sync for consensus")
 
 	notiC := make(chan error)
@@ -225,7 +224,7 @@ func SyncChain(hs *component.ComponentHub, targetHash []byte, targetNo types.Blo
 		}
 	}
 
-	logger.Info().Str("peer", p2putil.ShortForm(peerID)).Msg("succeeded to sync for consensus")
+	logger.Info().Stringer("peer", types.LogPeerShort(peerID)).Msg("succeeded to sync for consensus")
 	// TODO check best block is equal to target Hash/no
 	return nil
 }

--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -70,6 +71,7 @@ type BlockGenerator struct {
 	rejected *RejTxInfo
 	noTTE    bool // disable eviction by timeout if true
 
+	ctx              context.Context // block generation context
 	hs               component.ICompSyncRequester
 	bi               *types.BlockHeaderInfo
 	txOp             TxOp
@@ -78,11 +80,13 @@ type BlockGenerator struct {
 	maxBlockBodySize uint32
 }
 
-func NewBlockGenerator(hs component.ICompSyncRequester, bi *types.BlockHeaderInfo, bState *state.BlockState,
-	txOp TxOp, skipEmpty bool) *BlockGenerator {
+func NewBlockGenerator(hs component.ICompSyncRequester, ctx context.Context, bi *types.BlockHeaderInfo, bState *state.BlockState, txOp TxOp, skipEmpty bool) *BlockGenerator {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return &BlockGenerator{
-		bState: bState,
-
+		bState:           bState,
+		ctx:              ctx,
 		hs:               hs,
 		bi:               bi,
 		txOp:             txOp,

--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -22,7 +22,7 @@ var (
 	errBlockSizeLimit = errors.New("the transactions included exceeded the block size limit")
 )
 
-// ErrTimeout can be used to indicatefor any kind of timeout.
+// ErrTimeout can be used to indicate for any kind of timeout.
 type ErrTimeout struct {
 	Kind    string
 	Timeout int64

--- a/consensus/impl/dpos/blockfactory.go
+++ b/consensus/impl/dpos/blockfactory.go
@@ -33,13 +33,15 @@ const (
 )
 
 type txExec struct {
+	ctx    context.Context
 	execTx bc.TxExecFn
 }
 
-func newTxExec(cdb contract.ChainAccessor, bi *types.BlockHeaderInfo) chain.TxOp {
+func newTxExec(ctx context.Context, cdb contract.ChainAccessor, bi *types.BlockHeaderInfo) chain.TxOp {
 	// Block hash not determined yet
 	return &txExec{
-		execTx: bc.NewTxExecutor(nil, cdb, bi, contract.BlockFactory),
+		ctx:    ctx,
+		execTx: bc.NewTxExecutor(ctx, nil, cdb, bi, contract.BlockFactory),
 	}
 }
 
@@ -245,7 +247,7 @@ func (bf *BlockFactory) generateBlock(ctx context.Context, bpi *bpInfo, lpbNo ty
 	bs.Receipts().SetHardFork(bf.bv, bi.No)
 
 	bGen := chain.NewBlockGenerator(
-		bf, ctx, bi, bs, newTxExec(bpi.ChainDB, bi), false).
+		bf, ctx, bi, bs, newTxExec(ctx, bpi.ChainDB, bi), false).
 		WithDeco(bf.deco()).
 		SetNoTTE(bf.noTTE)
 

--- a/consensus/impl/dpos/blockfactory.go
+++ b/consensus/impl/dpos/blockfactory.go
@@ -7,6 +7,7 @@ package dpos
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"runtime"
 	"runtime/debug"
@@ -51,7 +52,7 @@ func (te *txExec) Apply(bState *state.BlockState, tx types.Transaction) error {
 type BlockFactory struct {
 	*component.ComponentHub
 	jobQueue         chan interface{}
-	workerQueue      chan *bpInfo
+	workerQueue      chan bfWork
 	bpTimeoutC       chan struct{}
 	quit             <-chan interface{}
 	maxBlockBodySize uint32
@@ -60,6 +61,9 @@ type BlockFactory struct {
 	txOp             chain.TxOp
 	sdb              *state.ChainStateDB
 	bv               types.BlockVersionner
+
+	ctx           context.Context
+	ctxCancelFunc context.CancelFunc
 
 	recentRejectedTx *chain.RejTxInfo
 	noTTE            bool
@@ -76,7 +80,7 @@ func NewBlockFactory(
 	bf := &BlockFactory{
 		ComponentHub:     hub,
 		jobQueue:         make(chan interface{}, slotQueueMax),
-		workerQueue:      make(chan *bpInfo),
+		workerQueue:      make(chan bfWork),
 		bpTimeoutC:       make(chan struct{}, 1),
 		maxBlockBodySize: chain.MaxBlockBodySize(),
 		quit:             quitC,
@@ -92,8 +96,19 @@ func NewBlockFactory(
 			return bf.checkBpTimeout()
 		}),
 	)
-	contract.SetBPTimeout(bf.bpTimeoutC)
+	bf.initContext()
 	return bf
+}
+
+func (bf *BlockFactory) initContext() {
+	// TODO change context to WithCancelCause later for more precise control
+	bf.ctx, bf.ctxCancelFunc = context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-bf.quit:
+			bf.ctxCancelFunc()
+		}
+	}()
 }
 
 func (bf *BlockFactory) setStateDB(sdb *state.ChainStateDB) {
@@ -124,27 +139,20 @@ func (bf *BlockFactory) controller() {
 			return err
 		}
 
-		timeLeft := bpi.slot.RemainingTimeMS()
-		if timeLeft <= 0 {
-			return chain.ErrTimeout{Kind: "slot", Timeout: timeLeft}
+		timeLeftMSs := bpi.slot.GetBpTimeout()
+		if timeLeftMSs <= 0 {
+			return chain.ErrTimeout{Kind: "slot", Timeout: timeLeftMSs}
 		}
+		bfContext, _ := context.WithTimeout(bf.ctx, time.Duration(timeLeftMSs)*time.Millisecond)
 
 		select {
-		case bf.workerQueue <- bpi:
+		case bf.workerQueue <- bfWork{context: bfContext, bpi: bpi}:
 		default:
 			logger.Error().Msgf(
 				"skip block production for the slot %v (best block: %v) due to a pending job",
 				spew.Sdump(bpi.slot), bpi.bestBlock.ID())
 		}
 		return nil
-	}
-
-	notifyBpTimeout := func(bpi *bpInfo) {
-		timeout := bpi.slot.GetBpTimeout()
-		time.Sleep(time.Duration(timeout) * time.Millisecond)
-		// TODO: skip when the triggered block has already been generated!
-		bf.bpTimeoutC <- struct{}{}
-		logger.Debug().Int64("timeout", timeout).Msg("block production timeout signaled")
 	}
 
 	for {
@@ -163,7 +171,7 @@ func (bf *BlockFactory) controller() {
 				continue
 			}
 
-			notifyBpTimeout(bpi)
+			//notifyBpTimeout(bpi)
 
 		case <-bf.quit:
 			return
@@ -182,9 +190,10 @@ func (bf *BlockFactory) worker() {
 
 	for {
 		select {
-		case bpi := <-bf.workerQueue:
+		case bfw := <-bf.workerQueue:
 		retry:
-			block, blockState, err := bf.generateBlock(bpi, lpbNo)
+			bpi := bfw.bpi
+			block, blockState, err := bf.generateBlock(bfw.context, bpi, lpbNo)
 			if err == chain.ErrQuit {
 				return
 			}
@@ -217,7 +226,7 @@ func (bf *BlockFactory) worker() {
 	}
 }
 
-func (bf *BlockFactory) generateBlock(bpi *bpInfo, lpbNo types.BlockNo) (block *types.Block, bs *state.BlockState, err error) {
+func (bf *BlockFactory) generateBlock(ctx context.Context, bpi *bpInfo, lpbNo types.BlockNo) (block *types.Block, bs *state.BlockState, err error) {
 	defer func() {
 		if panicMsg := recover(); panicMsg != nil {
 			block = nil
@@ -236,7 +245,7 @@ func (bf *BlockFactory) generateBlock(bpi *bpInfo, lpbNo types.BlockNo) (block *
 	bs.Receipts().SetHardFork(bf.bv, bi.No)
 
 	bGen := chain.NewBlockGenerator(
-		bf, bi, bs, chain.NewCompTxOp(bf.txOp, newTxExec(bpi.ChainDB, bi)), false).
+		bf, ctx, bi, bs, newTxExec(bpi.ChainDB, bi), false).
 		WithDeco(bf.deco()).
 		SetNoTTE(bf.noTTE)
 

--- a/consensus/impl/dpos/blockfactory.go
+++ b/consensus/impl/dpos/blockfactory.go
@@ -139,11 +139,11 @@ func (bf *BlockFactory) controller() {
 			return err
 		}
 
-		timeLeftMSs := bpi.slot.GetBpTimeout()
-		if timeLeftMSs <= 0 {
-			return chain.ErrTimeout{Kind: "slot", Timeout: timeLeftMSs}
+		timeLeftMS := bpi.slot.GetBpTimeout()
+		if timeLeftMS <= 0 {
+			return chain.ErrTimeout{Kind: "slot", Timeout: timeLeftMS}
 		}
-		bfContext, _ := context.WithTimeout(bf.ctx, time.Duration(timeLeftMSs)*time.Millisecond)
+		bfContext, _ := context.WithTimeout(bf.ctx, time.Duration(timeLeftMS)*time.Millisecond)
 
 		select {
 		case bf.workerQueue <- bfWork{execCtx: bfContext, bpi: bpi}:

--- a/consensus/impl/dpos/blockfactory_test.go
+++ b/consensus/impl/dpos/blockfactory_test.go
@@ -1,0 +1,54 @@
+package dpos
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestBlockFactory_context(t *testing.T) {
+	quitC := make(chan interface{})
+	factory := &BlockFactory{quit: quitC}
+	factory.initContext()
+
+	timeoutCtx, _ := context.WithTimeout(factory.ctx, time.Millisecond)
+	cancelCtx, cancelFunc := context.WithTimeout(factory.ctx, time.Minute)
+	quitCtx, _ := context.WithTimeout(factory.ctx, time.Minute)
+	time.Sleep(time.Millisecond * time.Duration(2))
+
+	// first channel is done by deadline
+	select {
+	case <-timeoutCtx.Done():
+		err := timeoutCtx.Err()
+		assert.Equal(t, context.DeadlineExceeded, err, "err by deadline")
+		//assert.Equal(t, err, context.Cause(timeoutCtx), "cause and err is differ")
+	default:
+		assert.Fail(t, "deadline expected, but not")
+	}
+
+	// second channel is canceled by self cancel func
+	cancelFunc()
+	select {
+	case <-cancelCtx.Done():
+		err := cancelCtx.Err()
+		assert.Equalf(t, context.Canceled, err, "err by cancel")
+		//assert.Equal(t, err, context.Cause(cancelCtx), "cause and err is differ")
+	default:
+		assert.Fail(t, "cancel expected, but not")
+	}
+
+	// third channel is canceled by parent with cause
+	close(quitC)
+	<-factory.ctx.Done()
+	assert.Equal(t, context.Canceled, factory.ctx.Err(), "factory err ErrQuit expected")
+	//assert.Equal(t, chain.ErrQuit, context.Cause(factory.ctx), "factory cause ErrQuit expected")
+	select {
+	case <-quitCtx.Done():
+		err := quitCtx.Err()
+		assert.Equalf(t, context.Canceled, err, "err by quit")
+		//assert.Equal(t, chain.ErrQuit, context.Cause(quitCtx), "cause ErrQuit expected")
+	default:
+		assert.Fail(t, "errQuit expected, but not")
+	}
+}

--- a/consensus/impl/dpos/dpos.go
+++ b/consensus/impl/dpos/dpos.go
@@ -6,6 +6,7 @@
 package dpos
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -77,6 +78,11 @@ func (bi *bpInfo) updateBestBlock() *types.Block {
 	}
 
 	return block
+}
+
+type bfWork struct {
+	context context.Context
+	bpi     *bpInfo
 }
 
 // GetName returns the name of the consensus.

--- a/consensus/impl/dpos/dpos.go
+++ b/consensus/impl/dpos/dpos.go
@@ -81,7 +81,7 @@ func (bi *bpInfo) updateBestBlock() *types.Block {
 }
 
 type bfWork struct {
-	context context.Context
+	execCtx context.Context
 	bpi     *bpInfo
 }
 

--- a/consensus/impl/dpos/slot/slot.go
+++ b/consensus/impl/dpos/slot/slot.go
@@ -107,7 +107,7 @@ func (s *Slot) IsFor(bpIdx bp.Index, bpCount uint16) bool {
 	return s.NextBpIndex(bpCount) == int64(bpIdx)
 }
 
-// GetBpTimeout returns the time available for block production.
+// GetBpTimeout returns the time available for block production in milliseconds.
 func (s *Slot) GetBpTimeout() int64 {
 	rTime := s.RemainingTimeMS()
 
@@ -136,7 +136,7 @@ func (s *Slot) NextBpIndex(bpCount uint16) int64 {
 
 // BpMaxTime returns the max time limit for block production in nsec.
 func BpMaxTime() time.Duration {
-	return time.Duration(bpMaxTimeLimitMs) * 1000
+	return time.Duration(bpMaxTimeLimitMs) * time.Millisecond
 }
 
 func msToPrevIndex(ms int64) int64 {

--- a/consensus/impl/dpos/slot/slot.go
+++ b/consensus/impl/dpos/slot/slot.go
@@ -136,7 +136,8 @@ func (s *Slot) NextBpIndex(bpCount uint16) int64 {
 
 // BpMaxTime returns the max time limit for block production in nsec.
 func BpMaxTime() time.Duration {
-	return time.Duration(bpMaxTimeLimitMs) * time.Millisecond
+	// FIXME this function has a bug. it returns 1/1000 of actual value.
+	return time.Duration(bpMaxTimeLimitMs) * 1000
 }
 
 func msToPrevIndex(ms int64) int64 {

--- a/consensus/impl/dpos/slot/slot.go
+++ b/consensus/impl/dpos/slot/slot.go
@@ -136,8 +136,7 @@ func (s *Slot) NextBpIndex(bpCount uint16) int64 {
 
 // BpMaxTime returns the max time limit for block production in nsec.
 func BpMaxTime() time.Duration {
-	// FIXME this function has a bug. it returns 1/1000 of actual value.
-	return time.Duration(bpMaxTimeLimitMs) * 1000
+	return time.Duration(bpMaxTimeLimitMs) * 1000000
 }
 
 func msToPrevIndex(ms int64) int64 {

--- a/consensus/impl/raftv2/blockfactory.go
+++ b/consensus/impl/raftv2/blockfactory.go
@@ -51,7 +51,7 @@ type txExec struct {
 func newTxExec(ccc consensus.ChainConsensusCluster, cdb consensus.ChainDB, bi *types.BlockHeaderInfo) chain.TxOp {
 	// Block hash not determined yet
 	return &txExec{
-		execTx: bc.NewTxExecutor(ccc, cdb, bi, contract.BlockFactory),
+		execTx: bc.NewTxExecutor(nil, ccc, cdb, bi, contract.BlockFactory),
 	}
 }
 

--- a/consensus/impl/raftv2/blockfactory.go
+++ b/consensus/impl/raftv2/blockfactory.go
@@ -193,8 +193,6 @@ func New(cfg *config.Config, hub *component.ComponentHub, cdb consensus.ChainWAL
 		}),
 	)
 
-	contract.SetBPTimeout(bf.bpTimeoutC)
-
 	return bf, nil
 }
 
@@ -516,7 +514,7 @@ func (bf *BlockFactory) generateBlock(work *Work) (*types.Block, *state.BlockSta
 	blockState.SetGasPrice(system.GetGasPriceFromState(blockState))
 	blockState.Receipts().SetHardFork(bf.bv, bi.No)
 
-	block, err := chain.NewBlockGenerator(bf, bi, blockState, txOp, RaftSkipEmptyBlock).GenerateBlock()
+	block, err := chain.NewBlockGenerator(bf, nil, bi, blockState, txOp, RaftSkipEmptyBlock).GenerateBlock()
 	if err == chain.ErrBlockEmpty {
 		//need reset previous work
 		return nil, nil, chain.ErrBlockEmpty

--- a/consensus/impl/raftv2/cluster.go
+++ b/consensus/impl/raftv2/cluster.go
@@ -696,7 +696,7 @@ func MaxUint64(x, y uint64) uint64 {
 				}
 
 				if state.Get() != types.RUNNING {
-					logger.Debug().Str("peer", p2putil.ShortForm(peerID)).Msg("peer is not running")
+					logger.Debug().Stringer("peer", types.LogPeerShort(peerID)).Msg("peer is not running")
 					continue
 
 				}

--- a/consensus/impl/raftv2/snapshot.go
+++ b/consensus/impl/raftv2/snapshot.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aergoio/aergo/v2/consensus"
 	"github.com/aergoio/aergo/v2/consensus/chain"
 	"github.com/aergoio/aergo/v2/p2p/p2pcommon"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/etcd/raft/raftpb"
@@ -182,12 +181,12 @@ func (chainsnap *ChainSnapshotter) requestSync(snap *consensus.ChainSnapshot) er
 				break
 			}
 
-			logger.Debug().Str("peer", p2putil.ShortForm(peerID)).Str("leader", EtcdIDToString(leader)).Msg("peer is not alive")
+			logger.Debug().Stringer("peer", types.LogPeerShort(peerID)).Str("leader", EtcdIDToString(leader)).Msg("peer is not alive")
 
 			time.Sleep(DfltTimeWaitPeerLive)
 		}
 
-		logger.Debug().Str("peer", p2putil.ShortForm(peerID)).Str("leader", EtcdIDToString(leader)).Msg("target peer to sync")
+		logger.Debug().Stringer("peer", types.LogPeerShort(peerID)).Str("leader", EtcdIDToString(leader)).Msg("target peer to sync")
 
 		return peerID, err
 	}

--- a/consensus/impl/sbp/sbp.go
+++ b/consensus/impl/sbp/sbp.go
@@ -34,7 +34,7 @@ type txExec struct {
 func newTxExec(cdb consensus.ChainDB, bi *types.BlockHeaderInfo) chain.TxOp {
 	// Block hash not determined yet
 	return &txExec{
-		execTx: bc.NewTxExecutor(nil, contract.ChainAccessor(cdb), bi, contract.BlockFactory),
+		execTx: bc.NewTxExecutor(nil, nil, contract.ChainAccessor(cdb), bi, contract.BlockFactory),
 	}
 }
 

--- a/consensus/impl/sbp/sbp.go
+++ b/consensus/impl/sbp/sbp.go
@@ -191,7 +191,7 @@ func (s *SimpleBlockFactory) Start() {
 				blockState.Receipts().SetHardFork(s.bv, bi.No)
 				txOp := chain.NewCompTxOp(s.txOp, newTxExec(s.ChainDB, bi))
 
-				block, err := chain.NewBlockGenerator(s, bi, blockState, txOp, false).GenerateBlock()
+				block, err := chain.NewBlockGenerator(s, nil, bi, blockState, txOp, false).GenerateBlock()
 				if err == chain.ErrQuit {
 					return
 				} else if err != nil {

--- a/consensus/impl/sbp/sbp.go
+++ b/consensus/impl/sbp/sbp.go
@@ -1,6 +1,7 @@
 package sbp
 
 import (
+	"context"
 	"runtime"
 	"time"
 
@@ -34,7 +35,8 @@ type txExec struct {
 func newTxExec(cdb consensus.ChainDB, bi *types.BlockHeaderInfo) chain.TxOp {
 	// Block hash not determined yet
 	return &txExec{
-		execTx: bc.NewTxExecutor(nil, nil, contract.ChainAccessor(cdb), bi, contract.BlockFactory),
+		// FIXME
+		execTx: bc.NewTxExecutor(context.Background(), nil, contract.ChainAccessor(cdb), bi, contract.BlockFactory),
 	}
 }
 
@@ -191,7 +193,7 @@ func (s *SimpleBlockFactory) Start() {
 				blockState.Receipts().SetHardFork(s.bv, bi.No)
 				txOp := chain.NewCompTxOp(s.txOp, newTxExec(s.ChainDB, bi))
 
-				block, err := chain.NewBlockGenerator(s, nil, bi, blockState, txOp, false).GenerateBlock()
+				block, err := chain.NewBlockGenerator(s, context.Background(), bi, blockState, txOp, false).GenerateBlock()
 				if err == chain.ErrQuit {
 					return
 				} else if err != nil {

--- a/consensus/impl/sbp/sbp.go
+++ b/consensus/impl/sbp/sbp.go
@@ -35,7 +35,7 @@ type txExec struct {
 func newTxExec(cdb consensus.ChainDB, bi *types.BlockHeaderInfo) chain.TxOp {
 	// Block hash not determined yet
 	return &txExec{
-		// FIXME
+		// FIXME block creation timeout check will not work in SBP unless the context is changed to context.WithTimeout()
 		execTx: bc.NewTxExecutor(context.Background(), nil, contract.ChainAccessor(cdb), bi, contract.BlockFactory),
 	}
 }

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -371,10 +371,6 @@ func useGas(version int32) bool {
 	return version >= 2 && PubNet
 }
 
-func SetBPTimeout(timeout <-chan struct{}) {
-	bpTimeout = timeout
-}
-
 func GasUsed(txFee, gasPrice *big.Int, txType types.TxType, version int32) uint64 {
 	if fee.IsZeroFee() || txType == types.TxType_GOVERNANCE || version < 2 {
 		return 0

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -65,7 +65,8 @@ func SetPreloadTx(tx *types.Tx, service int) {
 	preloaders[service].requestedTx = tx
 }
 
-func Execute(txCtx context.Context, bs *state.BlockState, cdb ChainAccessor, tx *types.Tx, sender, receiver *state.V, bi *types.BlockHeaderInfo, preloadService int, isFeeDelegation bool) (rv string, events []*types.Event, usedFee *big.Int, err error) {
+// Execute executes a normal transaction which is possibly executing smart contract.
+func Execute(execCtx context.Context, bs *state.BlockState, cdb ChainAccessor, tx *types.Tx, sender, receiver *state.V, bi *types.BlockHeaderInfo, preloadService int, isFeeDelegation bool) (rv string, events []*types.Event, usedFee *big.Int, err error) {
 
 	txBody := tx.GetBody()
 
@@ -180,7 +181,7 @@ func Execute(txCtx context.Context, bs *state.BlockState, cdb ChainAccessor, tx 
 		rv, events, ctrFee, err = PreCall(ex, bs, sender, contractState, receiver.RP(), gasLimit)
 	} else {
 		// create a new context
-		ctx := NewVmContext(txCtx, bs, cdb, sender, receiver, contractState, sender.ID(), tx.GetHash(), bi, "", true, false, receiver.RP(), preloadService, txBody.GetAmountBigInt(), gasLimit, isFeeDelegation)
+		ctx := NewVmContext(execCtx, bs, cdb, sender, receiver, contractState, sender.ID(), tx.GetHash(), bi, "", true, false, receiver.RP(), preloadService, txBody.GetAmountBigInt(), gasLimit, isFeeDelegation)
 
 		// execute the transaction
 		if receiver.IsDeploy() {

--- a/contract/errors.go
+++ b/contract/errors.go
@@ -53,7 +53,7 @@ func (e *VmSystemError) System() bool {
 type VmTimeoutError struct{}
 
 func (e *VmTimeoutError) Error() string {
-	return "contract timeout"
+	return "contract timeout of VmTimeoutError"
 }
 
 func (e *VmTimeoutError) System() bool {

--- a/contract/errors.go
+++ b/contract/errors.go
@@ -53,7 +53,7 @@ func (e *VmSystemError) System() bool {
 type VmTimeoutError struct{}
 
 func (e *VmTimeoutError) Error() string {
-	return "contract timeout of VmTimeoutError"
+	return "contract timeout during vm execution"
 }
 
 func (e *VmTimeoutError) System() bool {

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -54,7 +54,7 @@ const (
 	checkFeeDelegationFn = "check_delegation"
 	constructor          = "constructor"
 
-	vmTimeoutErrMsg = "[Contract.LuaCallContract] call err: contract timeout"
+	vmTimeoutErrMsg = "contract timeout of VmTimeoutError"
 )
 
 var (
@@ -607,8 +607,8 @@ func (ce *executor) call(instLimit C.int, target *LState) C.int {
 	}
 	ce.processArgs()
 	if ce.err != nil {
-		ctrLgr.Debug().Err(ce.err).Str("contract",
-			types.EncodeAddress(ce.ctx.curContract.contractId)).Msg("invalid argument")
+		ctrLgr.Debug().Err(ce.err).Stringer("contract",
+			types.LogAddr(ce.ctx.curContract.contractId)).Msg("invalid argument")
 		return 0
 	}
 	ce.setCountHook(instLimit)
@@ -629,9 +629,9 @@ func (ce *executor) call(instLimit C.int, target *LState) C.int {
 				ce.err = errors.New(errMsg)
 			}
 		}
-		ctrLgr.Debug().Err(ce.err).Str(
+		ctrLgr.Debug().Err(ce.err).Stringer(
 			"contract",
-			types.EncodeAddress(ce.ctx.curContract.contractId),
+			types.LogAddr(ce.ctx.curContract.contractId),
 		).Msg("contract is failed")
 		if target != nil {
 			if C.luaL_hasuncatchablerror(ce.L) != C.int(0) {
@@ -655,9 +655,9 @@ func (ce *executor) call(instLimit C.int, target *LState) C.int {
 		if c2ErrMsg := C.vm_copy_result(ce.L, target, nret); c2ErrMsg != nil {
 			errMsg := C.GoString(c2ErrMsg)
 			ce.err = errors.New(errMsg)
-			ctrLgr.Debug().Err(ce.err).Str(
+			ctrLgr.Debug().Err(ce.err).Stringer(
 				"contract",
-				types.EncodeAddress(ce.ctx.curContract.contractId),
+				types.LogAddr(ce.ctx.curContract.contractId),
 			).Msg("failed to move results")
 		}
 	}

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -610,8 +610,8 @@ func (ce *executor) call(instLimit C.int, target *LState) C.int {
 	nret := C.int(0)
 	startTime := time.Now()
 	cErrMsg := C.vm_pcall(ce.L, ce.numArgs, &nret)
-	vmExecTime := time.Now().Sub(startTime).Milliseconds()
-n	vmLogger.Trace().Int64("execMs", vmExecTime).Stringer("txHash", types.LogBase58(ce.ctx.txHash)).Msg("tx execute time in vm")
+	vmExecTime := time.Now().Sub(startTime).Microseconds()
+	vmLogger.Trace().Int64("execµs", vmExecTime).Stringer("txHash", types.LogBase58(ce.ctx.txHash)).Msg("tx execute time in vm")
 	if cErrMsg != nil {
 		errMsg := C.GoString(cErrMsg)
 		if C.luaL_hassyserror(ce.L) != C.int(0) {

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -21,6 +21,7 @@ package contract
 import "C"
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -85,6 +86,9 @@ type contractInfo struct {
 	amount     *big.Int
 }
 
+// vmContext contains context datas during execution of smart contract.
+// It has both call infos which are immutable, and real time statuses
+// which are mutable during execution
 type vmContext struct {
 	curContract       *contractInfo
 	bs                *state.BlockState
@@ -95,7 +99,7 @@ type vmContext struct {
 	node              string
 	confirmed         bool
 	isQuery           bool
-	nestedView        int32
+	nestedView        int32 // nestedView indicate which parent called called the contract in view (read-only mode)
 	isFeeDelegation   bool
 	service           C.int
 	callState         map[types.AccountID]*callState
@@ -108,6 +112,7 @@ type vmContext struct {
 	traceFile         *os.File
 	gasLimit          uint64
 	remainedGas       uint64
+	txContext         context.Context
 }
 
 type recoveryEntry struct {
@@ -173,9 +178,7 @@ func getTraceFile(blkno uint64, tx []byte) *os.File {
 	return f
 }
 
-func NewVmContext(blockState *state.BlockState, cdb ChainAccessor, sender, reciever *state.V,
-	contractState *state.ContractState, senderID []byte, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed bool,
-	query bool, rp uint64, service int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
+func NewVmContext(txContext context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, reciever *state.V, contractState *state.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed, query bool, rp uint64, service int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
 
 	cs := &callState{ctrState: contractState, curState: reciever.State()}
 
@@ -193,6 +196,7 @@ func NewVmContext(blockState *state.BlockState, cdb ChainAccessor, sender, recie
 		gasLimit:        gasLimit,
 		remainedGas:     gasLimit,
 		isFeeDelegation: feeDelegation,
+		txContext:       txContext,
 	}
 	ctx.callState = make(map[types.AccountID]*callState)
 	ctx.callState[reciever.AccountID()] = cs
@@ -225,6 +229,7 @@ func NewVmContextQuery(
 		confirmed:   true,
 		blockInfo:   types.NewBlockHeaderInfo(bb),
 		isQuery:     true,
+		txContext:   context.Background(), // FIXME query also should cancel if query is too long
 	}
 
 	ctx.callState = make(map[types.AccountID]*callState)
@@ -237,7 +242,7 @@ func (ctx *vmContext) IsGasSystem() bool {
 }
 
 // get the remaining gas from the given LState
-func (ctx *vmContext) getRemainingGas(L *LState) {
+func (ctx *vmContext) refreshRemainingGas(L *LState) {
 	if ctx.IsGasSystem() {
 		ctx.remainedGas = uint64(C.lua_gasget(L))
 	}
@@ -378,7 +383,7 @@ func newExecutor(
 	if ctx.IsGasSystem() {
 		ce.setGas()
 		defer func() {
-			ce.getRemainingGas()
+			ce.refreshRemainingGas()
 			if ctrLgr.IsDebugEnabled() {
 				ctrLgr.Debug().Uint64("gas used", ce.ctx.usedGas()).Str("lua vm", "loaded").Msg("gas information")
 			}
@@ -571,7 +576,7 @@ func (ce *executor) call(instLimit C.int, target *LState) C.int {
 	if ce.err != nil {
 		return 0
 	}
-	defer ce.getRemainingGas()
+	defer ce.refreshRemainingGas()
 	if ce.isView == true {
 		ce.ctx.nestedView++
 		defer func() {
@@ -611,7 +616,7 @@ func (ce *executor) call(instLimit C.int, target *LState) C.int {
 	startTime := time.Now()
 	cErrMsg := C.vm_pcall(ce.L, ce.numArgs, &nret)
 	vmExecTime := time.Now().Sub(startTime).Microseconds()
-	vmLogger.Trace().Int64("execµs", vmExecTime).Stringer("txHash", types.LogBase58(ce.ctx.txHash)).Msg("tx execute time in vm")
+	vmLogger.Trace().Int64("execµs", vmExecTime).Stringer("contract", types.LogAddr(ce.ctx.curContract.contractId)).Msg("contract execute time in vm")
 	if cErrMsg != nil {
 		errMsg := C.GoString(cErrMsg)
 		if C.luaL_hassyserror(ce.L) != C.int(0) {
@@ -789,8 +794,8 @@ func (ce *executor) close() {
 	}
 }
 
-func (ce *executor) getRemainingGas() {
-	ce.ctx.getRemainingGas(ce.L)
+func (ce *executor) refreshRemainingGas() {
+	ce.ctx.refreshRemainingGas(ce.L)
 }
 
 func (ce *executor) gas() uint64 {
@@ -845,8 +850,11 @@ func Call(
 	ce := newExecutor(contract, contractAddress, ctx, &ci, ctx.curContract.amount, false, false, contractState)
 	defer ce.close()
 
+	startTime := time.Now()
 	// execute the contract call
 	ce.call(callMaxInstLimit, nil)
+	vmExecTime := time.Now().Sub(startTime).Microseconds()
+	vmLogger.Trace().Int64("execµs", vmExecTime).Stringer("txHash", types.LogBase58(ce.ctx.txHash)).Msg("tx execute time in vm")
 
 	// check if there is an error
 	err = ce.err

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -1517,13 +1517,6 @@ func luaCheckTimeout(service C.int) C.int {
 		return 0
 	}
 
-	select {
-	case <-bpTimeout:
-		return 1
-	default:
-		return 0
-	}
-
 	// Temporarily disable timeout check to prevent contract timeout raised from chain service
 	// if service < BlockFactory {
 	// 	service = service + MaxVmService
@@ -1537,7 +1530,7 @@ func luaCheckTimeout(service C.int) C.int {
 	// default:
 	// 	return 0
 	// }
-	//return 0
+	return 0
 }
 
 //export luaIsFeeDelegation

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -343,7 +343,13 @@ func luaCallContract(L *LState, service C.int, contractId *C.char, fname *C.char
 		if ctx.traceFile != nil {
 			_, _ = ctx.traceFile.WriteString(fmt.Sprintf("recovery snapshot: %d\n", seq))
 		}
-		return -1, C.CString("[Contract.LuaCallContract] call err: " + ce.err.Error())
+		switch ceErr := ce.err.(type) {
+		case *VmTimeoutError:
+			return -1, C.CString(ceErr.Error())
+		default:
+			return -1, C.CString("[Contract.LuaCallContract] call err: " + ceErr.Error())
+
+		}
 	}
 
 	if seq == 1 {

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -29,6 +29,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/aergoio/aergo-lib/log"
 	"index/suffixarray"
 	"math/big"
 	"regexp"
@@ -50,6 +51,7 @@ import (
 var (
 	mulAergo, mulGaer, zeroBig *big.Int
 	creatorMetaKey             = []byte("Creator")
+	vmLogger                   = log.NewLogger("contract.vm")
 )
 
 const (
@@ -1492,6 +1494,10 @@ func luaCheckView(service C.int) C.int {
 	return C.int(ctx.nestedView)
 }
 
+// luaCheckTimeout checks two types of timeouts;
+// One is whether the block creation timeout is exceeded, and the other is whether
+// the transaction execution timeout is exceeded.
+//
 //export luaCheckTimeout
 func luaCheckTimeout(service C.int) C.int {
 

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -285,7 +285,7 @@ func luaCallContract(L *LState, service C.int, contractId *C.char, fname *C.char
 	}
 
 	// get the remaining gas from the parent LState
-	ctx.getRemainingGas(L)
+	ctx.refreshRemainingGas(L)
 	// create a new executor with the remaining gas on the child LState
 	ce := newExecutor(callee, cid, ctx, &ci, amountBig, false, false, cs.ctrState)
 	defer func() {
@@ -404,7 +404,7 @@ func luaDelegateCallContract(L *LState, service C.int, contractId *C.char,
 	}
 
 	// get the remaining gas from the parent LState
-	ctx.getRemainingGas(L)
+	ctx.refreshRemainingGas(L)
 	// create a new executor with the remaining gas on the child LState
 	ce := newExecutor(contract, cid, ctx, &ci, zeroBig, false, false, contractState)
 	defer func() {
@@ -527,7 +527,7 @@ func luaSendAmount(L *LState, service C.int, contractId *C.char, amount *C.char)
 		}
 
 		// get the remaining gas from the parent LState
-		ctx.getRemainingGas(L)
+		ctx.refreshRemainingGas(L)
 		// create a new executor with the remaining gas on the child LState
 		ce := newExecutor(code, cid, ctx, &ci, amountBig, false, false, cs.ctrState)
 		defer func() {
@@ -1235,7 +1235,7 @@ func luaDeployContract(
 	}
 
 	// get the remaining gas from the parent LState
-	ctx.getRemainingGas(L)
+	ctx.refreshRemainingGas(L)
 	// create a new executor with the remaining gas on the child LState
 	ce := newExecutor(runCode, newContract.ID(), ctx, &ci, amountBig, true, false, contractState)
 	defer func() {
@@ -1516,21 +1516,13 @@ func luaCheckTimeout(service C.int) C.int {
 	if service != BlockFactory {
 		return 0
 	}
-
-	// Temporarily disable timeout check to prevent contract timeout raised from chain service
-	// if service < BlockFactory {
-	// 	service = service + MaxVmService
-	// }
-	// if service != BlockFactory {
-	// 	return 0
-	// }
-	// select {
-	// case <-bpTimeout:
-	// 	return 1
-	// default:
-	// 	return 0
-	// }
-	return 0
+	ctx := contexts[service]
+	select {
+	case <-ctx.txContext.Done():
+		return 1
+	default:
+		return 0
+	}
 }
 
 //export luaIsFeeDelegation

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -1500,9 +1500,7 @@ func luaCheckView(service C.int) C.int {
 	return C.int(ctx.nestedView)
 }
 
-// luaCheckTimeout checks two types of timeouts;
-// One is whether the block creation timeout is exceeded, and the other is whether
-// the transaction execution timeout is exceeded.
+// luaCheckTimeout checks whether the block creation timeout occurred.
 //
 //export luaCheckTimeout
 func luaCheckTimeout(service C.int) C.int {
@@ -1522,9 +1520,10 @@ func luaCheckTimeout(service C.int) C.int {
 	if service != BlockFactory {
 		return 0
 	}
+
 	ctx := contexts[service]
 	select {
-	case <-ctx.txContext.Done():
+	case <-ctx.execCtx.Done():
 		return 1
 	default:
 		return 0

--- a/contract/vm_dummy/vm_dummy.go
+++ b/contract/vm_dummy/vm_dummy.go
@@ -633,7 +633,7 @@ func (bc *DummyChain) ConnectBlock(txs ...LuaTxTester) error {
 			timeout <- struct{}{}
 		}
 	}()
-	contract.SetBPTimeout(timeout)
+	//contract.SetBPTimeout(timeout)
 	for _, x := range txs {
 		if err := x.run(blockState, bc, types.NewBlockHeaderInfo(bc.cBlock), tx); err != nil {
 			return err

--- a/contract/vm_dummy/vm_dummy.go
+++ b/contract/vm_dummy/vm_dummy.go
@@ -626,13 +626,8 @@ func (bc *DummyChain) ConnectBlock(txs ...LuaTxTester) error {
 	defer tx.Commit()
 	defer contract.CloseDatabase()
 
-	timeout := make(chan struct{})
-	go func() {
-		if bc.timeout != 0 {
-			<-time.Tick(time.Duration(bc.timeout) * time.Millisecond)
-			timeout <- struct{}{}
-		}
-	}()
+	//timeout := make(chan struct{})
+	//blockContext, _ := context.WithTimeout(context.Background(), time.Duration(bc.timeout)*time.Millisecond)
 	//contract.SetBPTimeout(timeout)
 	for _, x := range txs {
 		if err := x.run(blockState, bc, types.NewBlockHeaderInfo(bc.cBlock), tx); err != nil {

--- a/contract/vm_dummy/vm_dummy_test.go
+++ b/contract/vm_dummy/vm_dummy_test.go
@@ -942,7 +942,7 @@ func xestInfiniteLoop(t *testing.T) {
 
 func TestInfiniteLoopOnPubNet(t *testing.T) {
 	// FIXME delete skip after gas limit patch
-	t.Skip("disabled until gas limit check is added")
+	//t.Skip("disabled until gas limit check is added")
 	code := readLuaCode("infiniteloop.lua")
 	require.NotEmpty(t, code, "failed to read infiniteloop.lua")
 

--- a/contract/vm_dummy/vm_dummy_test.go
+++ b/contract/vm_dummy/vm_dummy_test.go
@@ -941,6 +941,8 @@ func xestInfiniteLoop(t *testing.T) {
 }
 
 func TestInfiniteLoopOnPubNet(t *testing.T) {
+	// FIXME delete skip after gas limit patch
+	t.Skip("disabled until gas limit check is added")
 	code := readLuaCode("infiniteloop.lua")
 	require.NotEmpty(t, code, "failed to read infiniteloop.lua")
 
@@ -992,6 +994,8 @@ func TestUpdateSize(t *testing.T) {
 }
 
 func TestTimeoutCnt(t *testing.T) {
+	// FIXME delete skip after gas limit patch
+	t.Skip("disabled until gas limit check is added")
 	code := readLuaCode("timeout_1.lua")
 	require.NotEmpty(t, code, "failed to read timeout_1.lua")
 

--- a/contract/vm_dummy/vm_dummy_test.go
+++ b/contract/vm_dummy/vm_dummy_test.go
@@ -976,8 +976,6 @@ func xestInfiniteLoop(t *testing.T) {
 }
 
 func TestInfiniteLoopOnPubNet(t *testing.T) {
-	// FIXME delete skip after gas limit patch
-	//t.Skip("disabled until gas limit check is added")
 	code := readLuaCode(t, "infiniteloop.lua")
 
 	for version := min_version; version <= max_version; version++ {

--- a/p2p/certmanager.go
+++ b/p2p/certmanager.go
@@ -81,7 +81,7 @@ type bpCertificateManager struct {
 func (cm *bpCertificateManager) CreateCertificate(remoteMeta p2pcommon.PeerMeta) (*p2pcommon.AgentCertificateV1, error) {
 	if !types.IsSamePeerID(cm.settings.AgentID, remoteMeta.ID) {
 		// this agent is not in charge of that bp id.
-		cm.logger.Info().Str("agentID", p2putil.ShortForm(remoteMeta.ID)).Msg("failed to issue certificate, since peer is not registered agent")
+		cm.logger.Info().Stringer("agentID", types.LogPeerShort(remoteMeta.ID)).Msg("failed to issue certificate, since peer is not registered agent")
 		return nil, p2pcommon.ErrInvalidRole
 	}
 
@@ -161,12 +161,12 @@ func (cm *agentCertificateManager) AddCertificate(cert *p2pcommon.AgentCertifica
 	defer cm.mutex.Unlock()
 	if !p2putil.ContainsID(cm.self.ProducerIDs, cert.BPID) {
 		// this agent is not in charge of that bp id.
-		cm.logger.Info().Str("bpID", p2putil.ShortForm(cert.BPID)).Msg("drop issued certificate, since issuer is not my managed producer")
+		cm.logger.Info().Stringer("bpID", types.LogPeerShort(cert.BPID)).Msg("drop issued certificate, since issuer is not my managed producer")
 		return
 	}
 	if !types.IsSamePeerID(cm.self.ID, cert.AgentID) {
 		// this certificate is not my certificate
-		cm.logger.Info().Str("bpID", p2putil.ShortForm(cert.BPID)).Str("agentID", p2putil.ShortForm(cert.AgentID)).Msg("drop issued certificate, since agent id is not me")
+		cm.logger.Info().Stringer("bpID", types.LogPeerShort(cert.BPID)).Stringer("agentID", types.LogPeerShort(cert.AgentID)).Msg("drop issued certificate, since agent id is not me")
 		return
 	}
 

--- a/p2p/handshakev2.go
+++ b/p2p/handshakev2.go
@@ -72,7 +72,7 @@ func (h *InboundWireHandshaker) handleInboundPeer(ctx context.Context, rwc io.Re
 	if bestVer == p2pcommon.P2PVersionUnknown {
 		return h.writeErrAndReturn(fmt.Errorf("no matched p2p version for %v", hsReq.Versions), p2pcommon.HSCodeNoMatchedVersion, rwc)
 	} else {
-		h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Str("version", bestVer.String()).Msg("Responding best p2p version")
+		h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Str("version", bestVer.String()).Msg("Responding best p2p version")
 		resp := p2pcommon.HSHeadResp{Magic: hsReq.Magic, RespCode: bestVer.Uint32()}
 		err = h.writeWireHSResponse(resp, rwc)
 		select {
@@ -138,7 +138,7 @@ func (h *OutboundWireHandshaker) handleOutboundPeer(ctx context.Context, rwc io.
 		return nil, fmt.Errorf("remote peer failed: %v", respHeader.RespCode)
 	}
 	bestVersion := p2pcommon.P2PVersion(respHeader.RespCode)
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Str("version", bestVersion.String()).Msg("Responded best p2p version")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Str("version", bestVersion.String()).Msg("Responded best p2p version")
 	// continue to handshake with VersionedHandshaker
 	innerHS, err := h.verM.GetVersionedHandshaker(bestVersion, h.peerID, rwc)
 	if err != nil {

--- a/p2p/metric/metricsman.go
+++ b/p2p/metric/metricsman.go
@@ -80,7 +80,7 @@ func (mm *metricsManager) NewMetric(pid types.PeerID, manNum uint32) *PeerMetric
 	mm.mutex.Lock()
 	defer mm.mutex.Unlock()
 	if old, found := mm.metricsMap[pid]; found {
-		mm.logger.Warn().Str("peer_id", p2putil.ShortForm(pid)).Uint32("oldNum", old.seq).Uint32("newNum", manNum).Msg("metric for to add peer is already exist. replacing new metric")
+		mm.logger.Warn().Stringer("peer_id", types.LogPeerShort(pid)).Uint32("oldNum", old.seq).Uint32("newNum", manNum).Msg("metric for to add peer is already exist. replacing new metric")
 	}
 	peerMetric := &PeerMetric{mm: mm, PeerID: pid, seq: manNum, InMetric: NewExponentMetric5(mm.interval), OutMetric: NewExponentMetric5(mm.interval), Since: time.Now()}
 	mm.metricsMap[pid] = peerMetric
@@ -91,11 +91,11 @@ func (mm *metricsManager) Remove(pid types.PeerID, manNum uint32) *PeerMetric {
 	mm.mutex.Lock()
 	defer mm.mutex.Unlock()
 	if metric, found := mm.metricsMap[pid]; !found {
-		mm.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(pid)).Msg("metric for to remove peer is not exist.")
+		mm.logger.Warn().Stringer(p2putil.LogPeerID, types.LogPeerShort(pid)).Msg("metric for to remove peer is not exist.")
 		return nil
 	} else {
 		if metric.seq != manNum {
-			mm.logger.Warn().Uint32("exist_num", metric.seq).Uint32("man_num", manNum).Str(p2putil.LogPeerID, p2putil.ShortForm(pid)).Msg("ignore remove. different manage number")
+			mm.logger.Warn().Uint32("exist_num", metric.seq).Uint32("man_num", manNum).Stringer(p2putil.LogPeerID, types.LogPeerShort(pid)).Msg("ignore remove. different manage number")
 		}
 		atomic.AddInt64(&mm.deadTotalIn, metric.totalIn)
 		atomic.AddInt64(&mm.deadTotalOut, metric.totalOut)

--- a/p2p/msgorder.go
+++ b/p2p/msgorder.go
@@ -70,7 +70,7 @@ func (pr *pbRequestOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	p.reqMutex.Unlock()
 	err := p.rw.WriteMsg(pr.message)
 	if err != nil {
-		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
+		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
 		p.reqMutex.Lock()
 		delete(p.requests, pr.message.ID())
 		p.reqMutex.Unlock()
@@ -78,7 +78,7 @@ func (pr *pbRequestOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	}
 
 	if pr.trace {
-		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).
+		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).
 			Str(p2putil.LogMsgID, pr.GetMsgID().String()).Msg("Send request message")
 	}
 	return nil
@@ -92,11 +92,11 @@ func (pr *pbResponseOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	p := pi.(*remotePeerImpl)
 	err := p.rw.WriteMsg(pr.message)
 	if err != nil {
-		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
+		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
 		return err
 	}
 	if pr.trace {
-		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).
+		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).
 			Str(p2putil.LogMsgID, pr.GetMsgID().String()).Str(p2putil.LogOrgReqID, pr.message.OriginalID().String()).Msg("Send response message")
 	}
 
@@ -128,7 +128,7 @@ func (pr *pbBlkNoticeOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	if skipNotice || passedTime < MinNewBlkNoticeInterval {
 		p.skipCnt++
 		if p.skipCnt&0x03ff == 0 && pr.trace {
-			p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Int32("skip_cnt", p.skipCnt).Msg("Skipped NewBlockNotice ")
+			p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Int32("skip_cnt", p.skipCnt).Msg("Skipped NewBlockNotice ")
 
 		}
 		return nil
@@ -142,12 +142,12 @@ func (pr *pbBlkNoticeOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	}
 	err := p.rw.WriteMsg(pr.message)
 	if err != nil {
-		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
+		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
 		return err
 	}
 	p.lastBlkNoticeTime = time.Now()
 	if p.skipCnt > 100 && pr.trace {
-		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Int32("skip_cnt", p.skipCnt).Msg("Send NewBlockNotice after long skip")
+		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Int32("skip_cnt", p.skipCnt).Msg("Send NewBlockNotice after long skip")
 	}
 	p.skipCnt = 0
 	return nil
@@ -164,11 +164,11 @@ func (pr *pbBpNoticeOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	p.blkHashCache.ContainsOrAdd(blkHash, cachePlaceHolder)
 	err := p.rw.WriteMsg(pr.message)
 	if err != nil {
-		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
+		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
 		return err
 	}
 	if pr.trace {
-		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).
+		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).
 			Str(p2putil.LogMsgID, pr.GetMsgID().String()).Str(p2putil.LogBlkHash, enc.ToString(pr.block.Hash)).Msg("Notify block produced")
 	}
 	return nil
@@ -184,11 +184,11 @@ func (pr *pbTxNoticeOrder) SendTo(pi p2pcommon.RemotePeer) error {
 
 	err := p.rw.WriteMsg(pr.message)
 	if err != nil {
-		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
+		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to SendTo")
 		return err
 	}
 	if p.logger.IsDebugEnabled() && pr.trace {
-		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).
+		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).
 			Str(p2putil.LogMsgID, pr.GetMsgID().String()).Int("hash_cnt", len(pr.txHashes)).Array("hashes", types.NewLogTxIDsMarshaller(pr.txHashes, 10)).Msg("Sent tx notice")
 	}
 	return nil
@@ -231,12 +231,12 @@ func (pr *pbTossOrder) SendTo(pi p2pcommon.RemotePeer) error {
 	p := pi.(*remotePeerImpl)
 	err := p.rw.WriteMsg(pr.message)
 	if err != nil {
-		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to toss")
+		p.logger.Warn().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).Str(p2putil.LogMsgID, pr.GetMsgID().String()).Err(err).Msg("fail to toss")
 		return err
 	}
 
 	if pr.trace {
-		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Str(p2putil.LogProtoID, pr.GetProtocolID().String()).
+		p.logger.Debug().Str(p2putil.LogPeerName, p.Name()).Stringer(p2putil.LogProtoID, pr.GetProtocolID()).
 			Str(p2putil.LogMsgID, pr.GetMsgID().String()).Msg("toss message")
 	}
 	return nil

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -521,7 +521,7 @@ func (p2ps *P2P) initLocalSettings(conf *config.P2PConfig) {
 			if err != nil {
 				panic("invalid agentID " + conf.Agent + " : " + err.Error())
 			}
-			p2ps.Logger.Info().Str("fullID", pid.String()).Str("agentID", p2putil.ShortForm(pid)).Msg("found agent setting. use peer as agent if connected")
+			p2ps.Logger.Info().Str("fullID", pid.String()).Stringer("agentID", types.LogPeerShort(pid)).Msg("found agent setting. use peer as agent if connected")
 			p2ps.localSettings.AgentID = pid
 		} else {
 			p2ps.Logger.Debug().Msg("no agent was set. local peer is standalone producer.")

--- a/p2p/peerfinder.go
+++ b/p2p/peerfinder.go
@@ -75,7 +75,7 @@ func (dp *dynamicPeerFinder) OnPeerDisconnect(peer p2pcommon.RemotePeer) {
 }
 
 func (dp *dynamicPeerFinder) OnPeerConnect(pid types.PeerID) {
-	dp.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(pid)).Msg("check and remove peerID in pool")
+	dp.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(pid)).Msg("check and remove peerID in pool")
 	if stat := dp.qStats[pid]; stat == nil {
 		// first query will be sent quickly
 		dp.qStats[pid] = &queryStat{pid: pid, nextTurn: time.Now().Add(p2pcommon.PeerFirstInterval)}

--- a/p2p/peermanager.go
+++ b/p2p/peermanager.go
@@ -203,7 +203,7 @@ func (pm *peerManager) initDesignatedPeerList() {
 			pm.logger.Warn().Err(err).Str("str", addrStr).Msg("invalid NPAddPeer address")
 			continue
 		}
-		pm.logger.Info().Str(p2putil.LogFullID, peerMeta.ID.Pretty()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerMeta.ID)).Str("addr", peerMeta.Addresses[0].String()).Msg("Adding Designated peer")
+		pm.logger.Info().Str(p2putil.LogFullID, peerMeta.ID.Pretty()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerMeta.ID)).Str("addr", peerMeta.Addresses[0].String()).Msg("Adding Designated peer")
 		pm.designatedPeers[peerMeta.ID] = peerMeta
 	}
 }
@@ -328,14 +328,14 @@ func (pm *peerManager) tryRegister(hsResult connPeerResult) p2pcommon.RemotePeer
 	peerID := meta.ID
 	preExistPeer, ok := pm.remotePeers[peerID]
 	if ok {
-		pm.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("Peer add collision. Outbound connection of higher hash will survive.")
+		pm.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("Peer add collision. Outbound connection of higher hash will survive.")
 		iAmLowerOrEqual := p2putil.ComparePeerID(pm.is.SelfNodeID(), meta.ID) <= 0
 		if iAmLowerOrEqual == remote.Connection.Outbound {
-			pm.logger.Info().Str("local_peer_id", p2putil.ShortForm(pm.is.SelfNodeID())).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Bool("outbound", remote.Connection.Outbound).Msg("Close connection and keep earlier handshake connection.")
+			pm.logger.Info().Stringer("local_peer_id", types.LogPeerShort(pm.is.SelfNodeID())).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Bool("outbound", remote.Connection.Outbound).Msg("Close connection and keep earlier handshake connection.")
 			return nil
 		} else {
-			pm.logger.Info().Str("local_peer_id", p2putil.ShortForm(pm.is.SelfNodeID())).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Bool("outbound", remote.Connection.Outbound).Msg("Keep connection and close earlier handshake connection.")
-			pm.logger.Info().Str("local_peer_id", p2putil.ShortForm(pm.is.SelfNodeID())).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Bool("outbound", remote.Connection.Outbound).Msg("Keep connection and close earlier handshake connection.")
+			pm.logger.Info().Stringer("local_peer_id", types.LogPeerShort(pm.is.SelfNodeID())).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Bool("outbound", remote.Connection.Outbound).Msg("Keep connection and close earlier handshake connection.")
+			pm.logger.Info().Stringer("local_peer_id", types.LogPeerShort(pm.is.SelfNodeID())).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Bool("outbound", remote.Connection.Outbound).Msg("Keep connection and close earlier handshake connection.")
 			// stopping lower valued connection
 			preExistPeer.Stop()
 		}
@@ -418,14 +418,14 @@ func (pm *peerManager) removePeer(peer p2pcommon.RemotePeer) bool {
 		return false
 	}
 	if target.ManageNumber() != peer.ManageNumber() {
-		pm.logger.Debug().Uint32("remove_num", peer.ManageNumber()).Uint32("exist_num", target.ManageNumber()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("remove peer is requested but already removed and other instance is on")
+		pm.logger.Debug().Uint32("remove_num", peer.ManageNumber()).Uint32("exist_num", target.ManageNumber()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("remove peer is requested but already removed and other instance is on")
 		return false
 	}
 	if target.State() == types.RUNNING {
-		pm.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("remove peer is requested but peer is still running")
+		pm.logger.Warn().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("remove peer is requested but peer is still running")
 	}
 	pm.deletePeer(peer)
-	pm.logger.Info().Uint32("manage_num", peer.ManageNumber()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("removed peer in peermanager")
+	pm.logger.Info().Uint32("manage_num", peer.ManageNumber()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("removed peer in peermanager")
 
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()

--- a/p2p/raftsupport/concclusterreceiver.go
+++ b/p2p/raftsupport/concclusterreceiver.go
@@ -148,17 +148,17 @@ func (r *ConcurrentClusterInfoReceiver) handleInWaiting(peer p2pcommon.RemotePee
 	// remote peer response malformed data.
 	body, ok := msgBody.(*types.GetClusterInfoResponse)
 	if !ok {
-		r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Str(p2putil.LogMsgID, msg.ID().String()).Msg("get cluster invalid response data")
+		r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Stringer(p2putil.LogMsgID, msg.ID()).Msg("get cluster invalid response data")
 		return
 	} else if len(body.MbrAttrs) == 0 || body.Error != "" {
-		r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Str(p2putil.LogMsgID, msg.ID().String()).Err(errors.New(body.Error)).Msg("get cluster response empty member")
+		r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Stringer(p2putil.LogMsgID, msg.ID()).Err(errors.New(body.Error)).Msg("get cluster response empty member")
 		return
 	}
 
-	r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Str(p2putil.LogMsgID, msg.ID().String()).Object("resp", body).Msg("received get cluster response")
+	r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Stringer(p2putil.LogMsgID, msg.ID()).Object("resp", body).Msg("received get cluster response")
 	// return the result
 	if len(body.Error) != 0 {
-		r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Str(p2putil.LogMsgID, msg.ID().String()).Err(errors.New(body.Error)).Msg("get cluster response error")
+		r.logger.Debug().Str(p2putil.LogPeerName, peer.Name()).Stringer(p2putil.LogMsgID, msg.ID()).Err(errors.New(body.Error)).Msg("get cluster response error")
 		return
 	}
 	r.succResps[peer.ID()] = body
@@ -206,7 +206,7 @@ func (r *ConcurrentClusterInfoReceiver) calculate(err error) *message.GetCluster
 			}
 		}
 		if bestRsp != nil {
-			r.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(bestPid)).Object("resp", bestRsp).Msg("chosed best response")
+			r.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(bestPid)).Object("resp", bestRsp).Msg("chosed best response")
 			rsp.ClusterID = bestRsp.GetClusterID()
 			rsp.ChainID = bestRsp.GetChainID()
 			rsp.Members = bestRsp.GetMbrAttrs()

--- a/p2p/raftsupport/rafttransport.go
+++ b/p2p/raftsupport/rafttransport.go
@@ -105,7 +105,7 @@ func (t *AergoRaftTransport) Send(msgs []raftpb.Message) {
 			peer.SendMessage(t.mf.NewRaftMsgOrder(m.Type, &m))
 			continue
 		} else {
-			t.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(member.GetPeerID())).Msg("peer is unreachable")
+			t.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(member.GetPeerID())).Msg("peer is unreachable")
 			t.raftAcc.ReportUnreachable(member.GetPeerID())
 			continue
 		}
@@ -148,17 +148,17 @@ func (t *AergoRaftTransport) AddRemote(id rtypes.ID, urls []string) {
 func (t *AergoRaftTransport) AddPeer(id rtypes.ID, peerID types.PeerID, urls []string) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	t.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Str("id", id.String()).Msg("Adding member peer")
+	t.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Str("id", id.String()).Msg("Adding member peer")
 
 	member := t.raftAcc.GetMemberByID(uint64(id))
 	if member == nil {
-		t.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Str("id", id.String()).Msg("can't find member")
+		t.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Str("id", id.String()).Msg("can't find member")
 		return
 	}
 	st, exist := t.statuses[id]
 	if exist {
 		if _, exist := t.pm.GetPeer(member.GetPeerID()); exist {
-			t.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Str("id", id.String()).Msg("peer already exists")
+			t.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Str("id", id.String()).Msg("peer already exists")
 			st.activate()
 			return
 		} else {
@@ -200,7 +200,7 @@ func (t *AergoRaftTransport) RemovePeer(id rtypes.ID) {
 	if peer, exist := t.pm.GetPeer(st.pid); exist {
 		peer.Stop()
 	}
-	t.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(st.pid)).Uint64("raftID", uint64(id)).Msg("removed raft peer")
+	t.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(st.pid)).Uint64("raftID", uint64(id)).Msg("removed raft peer")
 }
 
 func (t *AergoRaftTransport) RemoveAllPeers() {
@@ -247,7 +247,7 @@ func (t *AergoRaftTransport) OnRaftSnapshot(s network.Stream) {
 	peer, found := t.pm.GetPeer(peerID)
 	if !found {
 		addr := s.Conn().RemoteMultiaddr()
-		t.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Str("multiaddr", addr.String()).Msg("snapshot stream from leader node")
+		t.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Str("multiaddr", addr.String()).Msg("snapshot stream from leader node")
 		hsresp.RespCode = p2pcommon.HSCodeAuthFail
 		s.Write(hsresp.Marshal())
 		s.Close()

--- a/p2p/raftsupport/status.go
+++ b/p2p/raftsupport/status.go
@@ -34,11 +34,11 @@ func (s *rPeerStatus) activate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.active {
-		s.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(s.pid)).Str("raftID", s.id.String()).Msgf("peer became active")
+		s.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(s.pid)).Str("raftID", s.id.String()).Msgf("peer became active")
 		s.active = true
 		s.since = time.Now()
 	} else {
-		s.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(s.pid)).Str("raftID", s.id.String()).Msgf("activate called to already active peer")
+		s.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(s.pid)).Str("raftID", s.id.String()).Msgf("activate called to already active peer")
 	}
 }
 
@@ -47,12 +47,12 @@ func (s *rPeerStatus) deactivate(cause string) {
 	defer s.mu.Unlock()
 
 	if s.active {
-		s.logger.Info().Str("cause", cause).Str(p2putil.LogPeerID, p2putil.ShortForm(s.pid)).Str("raftID", s.id.String()).Msgf("peer became inactive")
+		s.logger.Info().Str("cause", cause).Stringer(p2putil.LogPeerID, types.LogPeerShort(s.pid)).Str("raftID", s.id.String()).Msgf("peer became inactive")
 
 		s.active = false
 		s.since = time.Time{}
 	} else {
-		s.logger.Debug().Str("cause", cause).Str(p2putil.LogPeerID, p2putil.ShortForm(s.pid)).Str("raftID", s.id.String()).Msgf("deactivate called to already inactive peer")
+		s.logger.Debug().Str("cause", cause).Stringer(p2putil.LogPeerID, types.LogPeerShort(s.pid)).Str("raftID", s.id.String()).Msgf("deactivate called to already inactive peer")
 	}
 }
 

--- a/p2p/rolemanager.go
+++ b/p2p/rolemanager.go
@@ -44,12 +44,12 @@ func (rm *RaftRoleManager) UpdateBP(toAdd []types.PeerID, toRemove []types.PeerI
 	for _, pid := range toRemove {
 		delete(rm.raftBP, pid)
 		changes = append(changes, p2pcommon.RoleModifier{ID: pid, Role: types.PeerRole_Watcher})
-		rm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(pid)).Msg("raftBP removed")
+		rm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(pid)).Msg("raftBP removed")
 	}
 	for _, pid := range toAdd {
 		rm.raftBP[pid] = true
 		changes = append(changes, p2pcommon.RoleModifier{ID: pid, Role: types.PeerRole_Producer})
-		rm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(pid)).Msg("raftBP added")
+		rm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(pid)).Msg("raftBP added")
 	}
 	rm.is.PeerManager().UpdatePeerRole(changes)
 }

--- a/p2p/subproto/advice.go
+++ b/p2p/subproto/advice.go
@@ -32,7 +32,7 @@ func (a *LogHandleTimeAdvice) PreHandle() {
 func (a *LogHandleTimeAdvice) PostHandle(msg p2pcommon.Message, msgBody p2pcommon.MessageBody) {
 	a.logger.WithLevel(a.level).
 		Int64("elapsed", time.Since(a.timestamp).Nanoseconds()/1000).
-		Str(p2putil.LogProtoID, msg.Subprotocol().String()).
-		Str(p2putil.LogMsgID, msg.ID().String()).
+		Stringer(p2putil.LogProtoID, msg.Subprotocol()).
+		Stringer(p2putil.LogMsgID, msg.ID()).
 		Msg("handle takes")
 }

--- a/p2p/subproto/bp.go
+++ b/p2p/subproto/bp.go
@@ -117,7 +117,7 @@ func (h *toAgentBPNoticeHandler) Handle(msg p2pcommon.Message, msgBody p2pcommon
 		}
 
 		if !checkBPNoticeSender(bpID, remotePeer) {
-			h.logger.Debug().Err(err).Str(p2putil.LogPeerName, remotePeer.Name()).Str("bpID", p2putil.ShortForm(bpID)).Str("blockID", block.BlockID().String()).Msg("peer is not access right to send bp notice")
+			h.logger.Debug().Err(err).Str(p2putil.LogPeerName, remotePeer.Name()).Stringer("bpID", types.LogPeerShort(bpID)).Str("blockID", block.BlockID().String()).Msg("peer is not access right to send bp notice")
 			return
 		}
 

--- a/p2p/subproto/cert.go
+++ b/p2p/subproto/cert.go
@@ -124,13 +124,13 @@ func (h *certRenewedNoticeHandler) Handle(msg p2pcommon.Message, msgBody p2pcomm
 	if !p2putil.ContainsID(p.Meta().ProducerIDs, cert.BPID) {
 		// TODO add penalty
 		// this agent is not in charge of that bp id.
-		h.logger.Info().Str(p2putil.LogPeerName, p.Name()).Str("bpID", p2putil.ShortForm(cert.BPID)).Msg("drop renewed certificate, since issuer is not managed producer of remote peer")
+		h.logger.Info().Str(p2putil.LogPeerName, p.Name()).Stringer("bpID", types.LogPeerShort(cert.BPID)).Msg("drop renewed certificate, since issuer is not managed producer of remote peer")
 		return
 	}
 	if !types.IsSamePeerID(p.ID(), cert.AgentID) {
 		// TODO add penalty
 		// this certificate is not my certificate
-		h.logger.Info().Str(p2putil.LogPeerName, p.Name()).Str("bpID", p2putil.ShortForm(cert.BPID)).Str("agentID", p2putil.ShortForm(cert.AgentID)).Msg("drop renewed certificate, since agent id is not the remote peer")
+		h.logger.Info().Str(p2putil.LogPeerName, p.Name()).Stringer("bpID", types.LogPeerShort(cert.BPID)).Stringer("agentID", types.LogPeerShort(cert.AgentID)).Msg("drop renewed certificate, since agent id is not the remote peer")
 		return
 	}
 

--- a/p2p/subproto/getblock.go
+++ b/p2p/subproto/getblock.go
@@ -51,7 +51,7 @@ func (bh *blockRequestHandler) Handle(msg p2pcommon.Message, msgBody p2pcommon.M
 	if bh.issue() {
 		go bh.handleBlkReq(msg, data)
 	} else {
-		bh.logger.Info().Str(p2putil.LogProtoID, bh.protocol.String()).Str(p2putil.LogMsgID, msg.ID().String()).Str(p2putil.LogPeerName, remotePeer.Name()).Msg("return error for busy")
+		bh.logger.Info().Stringer(p2putil.LogProtoID, bh.protocol).Stringer(p2putil.LogMsgID, msg.ID()).Str(p2putil.LogPeerName, remotePeer.Name()).Msg("return error for busy")
 		resp := &types.GetBlockResponse{
 			Status: types.ResultStatus_RESOURCE_EXHAUSTED,
 			Blocks: nil, HasNext: false}
@@ -139,7 +139,7 @@ func (bh *blockRequestHandler) handleBlkReq(msg p2pcommon.Message, data *types.G
 	}
 }
 
-// newBlockRespHandler creates handler for GetBlockResponse
+// NewBlockRespHandler creates handler for GetBlockResponse
 func NewBlockRespHandler(pm p2pcommon.PeerManager, peer p2pcommon.RemotePeer, logger *log.Logger, actor p2pcommon.ActorService, sm p2pcommon.SyncManager) *blockResponseHandler {
 	bh := &blockResponseHandler{BaseMsgHandler{protocol: p2pcommon.GetBlocksResponse, pm: pm, sm: sm, peer: peer, actor: actor, logger: logger}}
 	return bh

--- a/p2p/subproto/ping.go
+++ b/p2p/subproto/ping.go
@@ -52,7 +52,7 @@ func (ph *pingRequestHandler) Handle(msg p2pcommon.Message, msgBody p2pcommon.Me
 	}
 
 	// generate response message
-	ph.logger.Debug().Str(p2putil.LogPeerName, remotePeer.Name()).Str(p2putil.LogMsgID, msg.ID().String()).Msg("Sending ping response")
+	ph.logger.Debug().Str(p2putil.LogPeerName, remotePeer.Name()).Stringer(p2putil.LogMsgID, msg.ID()).Msg("Sending ping response")
 	resp := &types.Pong{}
 	remotePeer.SendMessage(remotePeer.MF().NewMsgResponseOrder(msg.ID(), p2pcommon.PingResponse, resp))
 }

--- a/p2p/subproto/tx.go
+++ b/p2p/subproto/tx.go
@@ -52,7 +52,7 @@ func (th *txRequestHandler) Handle(msg p2pcommon.Message, msgBody p2pcommon.Mess
 	p2putil.DebugLogReceive(th.logger, th.protocol, msg.ID().String(), remotePeer, body)
 
 	if err := th.sm.HandleGetTxReq(remotePeer, msg.ID(), body); err != nil {
-		th.logger.Info().Str(p2putil.LogPeerName, remotePeer.Name()).Str(p2putil.LogMsgID, msg.ID().String()).Err(err).Msg("return err for concurrent get tx request")
+		th.logger.Info().Str(p2putil.LogPeerName, remotePeer.Name()).Stringer(p2putil.LogMsgID, msg.ID()).Err(err).Msg("return err for concurrent get tx request")
 		resp := &types.GetTransactionsResponse{
 			Status: types.ResultStatus_RESOURCE_EXHAUSTED,
 			Hashes: nil,
@@ -77,7 +77,7 @@ func (th *txResponseHandler) Handle(msg p2pcommon.Message, msgBody p2pcommon.Mes
 	p2putil.DebugLogReceiveResponse(th.logger, th.protocol, msg.ID().String(), msg.OriginalID().String(), th.peer, data)
 
 	if !remotePeer.GetReceiver(msg.OriginalID())(msg, data) {
-		th.logger.Warn().Str(p2putil.LogMsgID, msg.ID().String()).Msg("unknown getTX response")
+		th.logger.Warn().Stringer(p2putil.LogMsgID, msg.ID()).Msg("unknown getTX response")
 		remotePeer.ConsumeRequest(msg.OriginalID())
 	}
 }

--- a/p2p/syncmanager.go
+++ b/p2p/syncmanager.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aergoio/aergo-lib/log"
 	"github.com/aergoio/aergo/v2/chain"
-	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/aergoio/aergo/v2/message"
 	"github.com/aergoio/aergo/v2/p2p/p2pcommon"
 	"github.com/aergoio/aergo/v2/p2p/p2putil"
@@ -89,7 +88,7 @@ func (sm *syncManager) HandleNewBlockNotice(peer p2pcommon.RemotePeer, data *typ
 	// request block info if selfnode does not have block already
 	foundBlock, _ := sm.actor.GetChainAccessor().GetBlock(data.BlockHash)
 	if foundBlock == nil {
-		sm.logger.Debug().Str(p2putil.LogBlkHash, enc.ToString(data.BlockHash)).Str(p2putil.LogPeerName, peer.Name()).Msg("new block notice of unknown hash. request back to notifier")
+		sm.logger.Debug().Stringer(p2putil.LogBlkHash, types.LogBase58(data.BlockHash)).Str(p2putil.LogPeerName, peer.Name()).Msg("new block notice of unknown hash. request back to notifier")
 		sm.actor.SendRequest(message.P2PSvc, &message.GetBlockInfos{ToWhom: peerID,
 			Hashes: []message.BlockHash{message.BlockHash(data.BlockHash)}})
 	}

--- a/p2p/synctx.go
+++ b/p2p/synctx.go
@@ -191,7 +191,7 @@ func (tm *syncTxManager) HandleNewTxNotice(peer p2pcommon.RemotePeer, txIDs []ty
 			tm.toNoticeIdQueue.PushBack(&queryQueue{peerID: peerID, txIDs: toQueue})
 		}
 
-		tm.logger.Trace().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Int("newCnt", len(newComer)).Int("queCnt", len(queued)).Int("dupCnt", len(duplicated)).Array("newComer", types.NewLogTxIDsMarshaller(newComer, 10)).Array("duplicated", types.NewLogTxIDsMarshaller(duplicated, 10)).Array("queued", types.NewLogTxIDsMarshaller(queued, 10)).Int("frontCacheSize", len(tm.frontCache)).Msg("push txs, to query next time")
+		tm.logger.Trace().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Int("newCnt", len(newComer)).Int("queCnt", len(queued)).Int("dupCnt", len(duplicated)).Array("newComer", types.NewLogTxIDsMarshaller(newComer, 10)).Array("duplicated", types.NewLogTxIDsMarshaller(duplicated, 10)).Array("queued", types.NewLogTxIDsMarshaller(queued, 10)).Int("frontCacheSize", len(tm.frontCache)).Msg("push txs, to query next time")
 	}
 }
 
@@ -220,7 +220,7 @@ func (tm *syncTxManager) retryGetTx(peerID types.PeerID, hashes [][]byte) {
 		for i, hash := range hashes {
 			txIDs[i] = types.ToTxID(hash)
 		}
-		tm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Array("txIDs", types.NewLogTxIDsMarshaller(txIDs, 10)).Msg("push txs that are failed to get by server busy")
+		tm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Array("txIDs", types.NewLogTxIDsMarshaller(txIDs, 10)).Msg("push txs that are failed to get by server busy")
 		tm.pushBackToFrontCache(peerID, txIDs)
 	}
 }
@@ -464,7 +464,7 @@ func (tm *syncTxManager) refineFrontCache() {
 			tm.sendGetTx(peer, ids)
 		} else {
 			// peer probably disconnected.
-			tm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Array("hashes", types.NewLogTxIDsMarshaller(ids, 10)).Msg("syncManager failed to send get tx, since peer is disconnected just before")
+			tm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Array("hashes", types.NewLogTxIDsMarshaller(ids, 10)).Msg("syncManager failed to send get tx, since peer is disconnected just before")
 			toRetry := make([]types.TxID, len(ids))
 			copy(toRetry, ids)
 			tm.burnFailedTxFrontCache(peerID, toRetry)

--- a/p2p/transport/networktransport.go
+++ b/p2p/transport/networktransport.go
@@ -117,12 +117,12 @@ func (sl *networkTransport) AddStreamHandler(pid core.ProtocolID, handler networ
 func (sl *networkTransport) GetOrCreateStreamWithTTL(meta p2pcommon.PeerMeta, ttl time.Duration, protocolIDs ...core.ProtocolID) (core.Stream, error) {
 	var peerAddr = meta.Addresses[0]
 	var peerID = meta.ID
-	sl.logger.Debug().Str("peerAddr", peerAddr.String()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("connecting to peer")
+	sl.logger.Debug().Str("peerAddr", peerAddr.String()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("connecting to peer")
 	sl.Peerstore().AddAddr(peerID, peerAddr, ttl)
 	ctx := context.Background()
 	s, err := sl.NewStream(ctx, peerID, protocolIDs...)
 	if err != nil {
-		sl.logger.Info().Err(err).Str("addr", peerAddr.String()).Str(p2putil.LogPeerID, p2putil.ShortForm(meta.ID)).Str("p2p_proto", p2putil.ProtocolIDsToString(protocolIDs)).Msg("Error while get stream")
+		sl.logger.Info().Err(err).Str("addr", peerAddr.String()).Stringer(p2putil.LogPeerID, types.LogPeerShort(meta.ID)).Str("p2p_proto", p2putil.ProtocolIDsToString(protocolIDs)).Msg("Error while get stream")
 		return nil, err
 	}
 	return s, nil
@@ -178,7 +178,7 @@ func (sl *networkTransport) startListener() {
 		panic(err.Error())
 	}
 	sl.Host = newHost
-	sl.logger.Info().Str(p2putil.LogFullID, sl.ID().Pretty()).Str(p2putil.LogPeerID, p2putil.ShortForm(sl.ID())).Str("addr[0]", listens[0].String()).Msg("Set self node's pid, and listening for connections")
+	sl.logger.Info().Str(p2putil.LogFullID, sl.ID().Pretty()).Stringer(p2putil.LogPeerID, types.LogPeerShort(sl.ID())).Str("addr[0]", listens[0].String()).Msg("Set self node's pid, and listening for connections")
 }
 
 func (sl *networkTransport) Stop() error {

--- a/p2p/v030/v030handshake.go
+++ b/p2p/v030/v030handshake.go
@@ -46,7 +46,7 @@ func NewV030VersionedHS(pm p2pcommon.PeerManager, actor p2pcommon.ActorService, 
 
 // handshakeOutboundPeer start handshake with outbound peer
 func (h *V030Handshaker) DoForOutbound(ctx context.Context) (*p2pcommon.HandshakeResult, error) {
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Starting versioned handshake for outbound peer connection")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Starting versioned handshake for outbound peer connection")
 	bestBlock, err := h.actor.GetChainAccessor().GetBestBlock()
 	if err != nil {
 		return nil, err
@@ -81,13 +81,13 @@ func (h *V030Handshaker) sendLocalStatus(ctx context.Context, hostStatus *types.
 	var err error
 	container := createMessage(p2pcommon.StatusRequest, p2pcommon.NewMsgID(), hostStatus)
 	if container == nil {
-		h.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("failed to create p2p message")
+		h.logger.Warn().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("failed to create p2p message")
 		h.sendGoAway("internal error")
 		// h.logger.Warn().Str(LogPeerID, ShortForm(peerID)).Err(err).Msg("failed to create p2p message")
 		return fmt.Errorf("failed to craete container message")
 	}
 	if err = h.msgRW.WriteMsg(container); err != nil {
-		h.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Err(err).Msg("failed to write local status ")
+		h.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Err(err).Msg("failed to write local status ")
 		return err
 	}
 	select {
@@ -117,7 +117,7 @@ func (h *V030Handshaker) receiveRemoteStatus(ctx context.Context) (*types.Status
 		if data.Subprotocol() == p2pcommon.GoAway {
 			return h.handleGoAway(h.peerID, data)
 		} else {
-			h.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Str("expected", p2pcommon.StatusRequest.String()).Str("actual", data.Subprotocol().String()).Msg("unexpected message type")
+			h.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Str("expected", p2pcommon.StatusRequest.String()).Str("actual", data.Subprotocol().String()).Msg("unexpected message type")
 			h.sendGoAway("unexpected message type")
 			return nil, fmt.Errorf("unexpected message type")
 		}
@@ -175,7 +175,7 @@ func (h *V030Handshaker) checkRemoteStatus(remotePeerStatus *types.Status) error
 
 	rMeta := p2pcommon.NewMetaFromStatus(remotePeerStatus)
 	if rMeta.ID != h.peerID {
-		h.logger.Debug().Str("received_peer_id", rMeta.ID.Pretty()).Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Inconsistent peerID")
+		h.logger.Debug().Str("received_peer_id", rMeta.ID.Pretty()).Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Inconsistent peerID")
 		h.sendGoAway("Inconsistent peerID")
 		return fmt.Errorf("Inconsistent peerID")
 	}
@@ -186,7 +186,7 @@ func (h *V030Handshaker) checkRemoteStatus(remotePeerStatus *types.Status) error
 
 // DoForInbound is handle handshake from inbound peer
 func (h *V030Handshaker) DoForInbound(ctx context.Context) (*p2pcommon.HandshakeResult, error) {
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Starting versioned handshake for inbound peer connection")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Starting versioned handshake for inbound peer connection")
 
 	// inbound: receive, check and send
 	remotePeerStatus, err := h.receiveRemoteStatus(ctx)
@@ -219,7 +219,7 @@ func (h *V030Handshaker) DoForInbound(ctx context.Context) (*p2pcommon.Handshake
 func (h *V030Handshaker) handleGoAway(peerID types.PeerID, data p2pcommon.Message) (*types.Status, error) {
 	goAway := &types.GoAwayNotice{}
 	if err := p2putil.UnmarshalMessageBody(data.Payload(), goAway); err != nil {
-		h.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Err(err).Msg("Remote peer sent goAway but failed to decode internal message")
+		h.logger.Warn().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Err(err).Msg("Remote peer sent goAway but failed to decode internal message")
 		return nil, err
 	}
 	return nil, fmt.Errorf("remote peer refuse handshake: %s", goAway.GetMessage())

--- a/p2p/v030/v032handshake.go
+++ b/p2p/v030/v032handshake.go
@@ -54,7 +54,7 @@ func (h *V032Handshaker) checkRemoteStatus(remotePeerStatus *types.Status) error
 }
 
 func (h *V032Handshaker) DoForOutbound(ctx context.Context) (*p2pcommon.HandshakeResult, error) {
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Starting versioned handshake for outbound peer connection")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Starting versioned handshake for outbound peer connection")
 
 	bestBlock, err := h.actor.GetChainAccessor().GetBestBlock()
 	if err != nil {
@@ -88,7 +88,7 @@ func (h *V032Handshaker) DoForOutbound(ctx context.Context) (*p2pcommon.Handshak
 }
 
 func (h *V032Handshaker) DoForInbound(ctx context.Context) (*p2pcommon.HandshakeResult, error) {
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Starting versioned handshake for inbound peer connection")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Starting versioned handshake for inbound peer connection")
 
 	// inbound: receive, check and send
 	remotePeerStatus, err := h.receiveRemoteStatus(ctx)

--- a/p2p/v030/v033handshake.go
+++ b/p2p/v030/v033handshake.go
@@ -66,7 +66,7 @@ func (h *V033Handshaker) checkRemoteStatus(remotePeerStatus *types.Status) error
 
 	rMeta := p2pcommon.NewMetaFromStatus(remotePeerStatus)
 	if rMeta.ID != h.peerID {
-		h.logger.Debug().Str("received_peer_id", rMeta.ID.Pretty()).Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Inconsistent peerID")
+		h.logger.Debug().Str("received_peer_id", rMeta.ID.Pretty()).Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Inconsistent peerID")
 		h.sendGoAway("Inconsistent peerID")
 		return fmt.Errorf("inconsistent peerID")
 	}
@@ -83,7 +83,7 @@ func (h *V033Handshaker) checkRemoteStatus(remotePeerStatus *types.Status) error
 }
 
 func (h *V033Handshaker) DoForOutbound(ctx context.Context) (*p2pcommon.HandshakeResult, error) {
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Starting versioned handshake for outbound peer connection")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Starting versioned handshake for outbound peer connection")
 
 	// find my best block
 	bestBlock, err := h.actor.GetChainAccessor().GetBestBlock()
@@ -119,7 +119,7 @@ func (h *V033Handshaker) DoForOutbound(ctx context.Context) (*p2pcommon.Handshak
 }
 
 func (h *V033Handshaker) DoForInbound(ctx context.Context) (*p2pcommon.HandshakeResult, error) {
-	h.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(h.peerID)).Msg("Starting versioned handshake for inbound peer connection")
+	h.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(h.peerID)).Msg("Starting versioned handshake for inbound peer connection")
 
 	// inbound: receive, check and send
 	remotePeerStatus, err := h.receiveRemoteStatus(ctx)

--- a/p2p/v200/v200handshake_test.go
+++ b/p2p/v200/v200handshake_test.go
@@ -459,7 +459,7 @@ func TestV200Handshaker_checkAgent(t *testing.T) {
 		id, _ := types.IDFromPrivateKey(priv)
 		producerIDs[i] = id
 		certs[i], _ = p2putil.NewAgentCertV1(id, agentID, p2putil.ConvertPKToBTCEC(priv), []string{ipExternal1}, time.Hour*24)
-		logger.Info().Str("peerID", p2putil.ShortForm(id)).Int("idx", i).Msg("producer id")
+		logger.Info().Stringer("peerID", types.LogPeerShort(id)).Int("idx", i).Msg("producer id")
 	}
 	pCerts, _ := p2putil.ConvertCertsToProto(certs)
 	wrongCert := *certs[0]

--- a/p2p/waitpeermanager.go
+++ b/p2p/waitpeermanager.go
@@ -55,7 +55,7 @@ func (dpm *basePeerManager) OnInboundConn(s network.Stream) {
 	addr := s.Conn().RemoteMultiaddr()
 	ip, port, err := types.GetIPPortFromMultiaddr(addr)
 	if err != nil {
-		dpm.logger.Warn().Err(err).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("Can't get ip address and port from inbound peer")
+		dpm.logger.Warn().Err(err).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("Can't get ip address and port from inbound peer")
 		s.Close()
 	}
 	conn := p2pcommon.RemoteConn{Outbound: false, IP: ip, Port: port}
@@ -63,7 +63,7 @@ func (dpm *basePeerManager) OnInboundConn(s network.Stream) {
 
 	dpm.logger.Info().Str(p2putil.LogFullID, peerID.Pretty()).Str("multiaddr", addr.String()).Msg("new inbound peer arrived")
 	if banned, _ := dpm.lm.IsBanned(ip.String(), peerID); banned {
-		dpm.logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Str("multiaddr", addr.String()).Msg("inbound peer is banned by list manager")
+		dpm.logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Str("multiaddr", addr.String()).Msg("inbound peer is banned by list manager")
 		s.Close()
 		return
 	}
@@ -71,7 +71,7 @@ func (dpm *basePeerManager) OnInboundConn(s network.Stream) {
 	query := inboundConnEvent{conn: conn, meta: tempMeta, p2pVer: p2pcommon.P2PVersionUnknown, foundC: make(chan bool)}
 	dpm.pm.inboundConnChan <- query
 	if exist := <-query.foundC; exist {
-		dpm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("same peer as inbound peer already exists.")
+		dpm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("same peer as inbound peer already exists.")
 		s.Close()
 		return
 	}
@@ -133,7 +133,7 @@ func (dpm *basePeerManager) connectWaitingPeers(maxJob int) {
 			//	dpm.logger.Info().Str(p2putil.LogPeerName, p2putil.ShortMetaForm(wp.Meta)).Msg("Skipping banned peer")
 			//	continue
 			//}
-			dpm.logger.Info().Int("trial", wp.TrialCnt).Str(p2putil.LogPeerID, p2putil.ShortForm(wp.Meta.ID)).Msg("Starting scheduled try to connect peer")
+			dpm.logger.Info().Int("trial", wp.TrialCnt).Stringer(p2putil.LogPeerID, types.LogPeerShort(wp.Meta.ID)).Msg("Starting scheduled try to connect peer")
 
 			dpm.workingJobs[wp.Meta.ID] = ConnWork{Meta: wp.Meta, PeerID: wp.Meta.ID, StartTime: time.Now()}
 			go dpm.runTryOutboundConnect(wp)
@@ -168,7 +168,7 @@ func (dpm *basePeerManager) runTryOutboundConnect(wp *p2pcommon.WaitingPeer) {
 	meta := wp.Meta
 	s, err := dpm.getStream(meta)
 	if err != nil {
-		dpm.logger.Info().Err(err).Str(p2putil.LogPeerID, p2putil.ShortForm(meta.ID)).Msg("Failed to get stream.")
+		dpm.logger.Info().Err(err).Stringer(p2putil.LogPeerID, types.LogPeerShort(meta.ID)).Msg("Failed to get stream.")
 		workResult.Result = err
 		return
 	}
@@ -181,7 +181,7 @@ func (dpm *basePeerManager) runTryOutboundConnect(wp *p2pcommon.WaitingPeer) {
 		return
 		//} else {
 		//	if meta.IPAddress != completeMeta.IPAddress {
-		//		dpm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(completeMeta.ID)).Str("before", meta.IPAddress).Str("after", completeMeta.IPAddress).Msg("IP address of remote peer is changed to ")
+		//		dpm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(completeMeta.ID)).Str("before", meta.IPAddress).Str("after", completeMeta.IPAddress).Msg("IP address of remote peer is changed to ")
 		//	}
 	}
 }
@@ -206,7 +206,7 @@ func (dpm *basePeerManager) getStream(meta p2pcommon.PeerMeta) (network.Stream, 
 func (dpm *basePeerManager) tryAddPeer(outbound bool, meta p2pcommon.PeerMeta, s network.Stream, h p2pcommon.HSHandler) (p2pcommon.PeerMeta, bool) {
 	hResult, err := h.Handle(s, defaultHandshakeTTL)
 	if err != nil {
-		dpm.logger.Debug().Err(err).Bool("outbound", outbound).Str(p2putil.LogPeerID, p2putil.ShortForm(meta.ID)).Msg("Failed to handshake")
+		dpm.logger.Debug().Err(err).Bool("outbound", outbound).Stringer(p2putil.LogPeerID, types.LogPeerShort(meta.ID)).Msg("Failed to handshake")
 		return meta, false
 	}
 
@@ -240,7 +240,7 @@ func (dpm *basePeerManager) createRemoteInfo(conn network.Conn, r p2pcommon.Hand
 		if len(r.Certificates) > 0 {
 			ri.AcceptedRole = types.PeerRole_Agent
 		} else {
-			dpm.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(r.Meta.ID)).Msg("treat peer which claims agent but with no certificates, as Watcher")
+			dpm.logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(r.Meta.ID)).Msg("treat peer which claims agent but with no certificates, as Watcher")
 		}
 	default:
 		ri.AcceptedRole = r.Meta.Role

--- a/polaris/client/polarisconnect.go
+++ b/polaris/client/polarisconnect.go
@@ -139,9 +139,9 @@ func (pcs *PolarisConnectSvc) queryPeers(msg *message.MapQueryMsg) *message.MapQ
 		addrs, err := pcs.connectAndQuery(meta, msg.BestBlock.Hash, msg.BestBlock.Header.BlockNo)
 		if err != nil {
 			if err == ErrTooLowVersion {
-				pcs.Logger.Error().Err(err).Str("polarisID", p2putil.ShortForm(meta.ID)).Msg("Polaris responded this aergosvr is too low, check and upgrade aergosvr")
+				pcs.Logger.Error().Err(err).Stringer("polarisID", types.LogPeerShort(meta.ID)).Msg("Polaris responded this aergosvr is too low, check and upgrade aergosvr")
 			} else {
-				pcs.Logger.Warn().Err(err).Str("polarisID", p2putil.ShortForm(meta.ID)).Msg("failed to get peer addresses")
+				pcs.Logger.Warn().Err(err).Stringer("polarisID", types.LogPeerShort(meta.ID)).Msg("failed to get peer addresses")
 			}
 			continue
 		}

--- a/polaris/server/mapservice.go
+++ b/polaris/server/mapservice.go
@@ -124,10 +124,10 @@ func (pms *PeerMapService) onConnect(s types.Stream) {
 	peerID := s.Conn().RemotePeer()
 	remoteIP, port, err := types.GetIPPortFromMultiaddr(s.Conn().RemoteMultiaddr())
 	if err != nil {
-		pms.Logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("Invalid address information")
+		pms.Logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("Invalid address information")
 		return
 	}
-	pms.Logger.Info().Str("addr", s.Conn().RemoteMultiaddr().String()).Str(p2putil.LogFullID, peerID.Pretty()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("remote peer connected")
+	pms.Logger.Info().Str("addr", s.Conn().RemoteMultiaddr().String()).Str(p2putil.LogFullID, peerID.Pretty()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("remote peer connected")
 
 	conn := p2pcommon.RemoteConn{IP: remoteIP, Port: port, Outbound: false}
 	tempMeta := p2pcommon.PeerMeta{ID: peerID, Addresses: []types.Multiaddr{s.Conn().RemoteMultiaddr()}}
@@ -137,27 +137,27 @@ func (pms *PeerMapService) onConnect(s types.Stream) {
 	// receive input
 	container, query, err := pms.readRequest(remotePeerInfo, rw)
 	if err != nil {
-		pms.Logger.Info().Err(err).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("failed to read query")
+		pms.Logger.Info().Err(err).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("failed to read query")
 		return
 	}
 
 	// check blacklist
 	if banned, _ := pms.lm.IsBanned(remoteIP.String(), peerID); banned {
-		pms.Logger.Info().Str("address", remoteIP.String()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("close soon banned peer")
+		pms.Logger.Info().Str("address", remoteIP.String()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("close soon banned peer")
 		return
 	}
 	resp, err := pms.handleQuery(conn, container, query)
 	if err != nil {
-		pms.Logger.Info().Err(err).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("failed to handle query")
+		pms.Logger.Info().Err(err).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("failed to handle query")
 		return
 	}
 
 	// response to peer
 	if err = pms.writeResponse(container, remotePeerInfo, resp, rw); err != nil {
-		pms.Logger.Info().Err(err).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("failed to write query")
+		pms.Logger.Info().Err(err).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("failed to write query")
 		return
 	}
-	pms.Logger.Debug().Str("status", resp.Status.String()).Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Int("peer_cnt", len(resp.Addresses)).Msg("Sent map response")
+	pms.Logger.Debug().Str("status", resp.Status.String()).Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Int("peer_cnt", len(resp.Addresses)).Msg("Sent map response")
 
 	// TODO send goodbye message.
 	time.Sleep(time.Second * 3)
@@ -321,7 +321,7 @@ func isEqualMeta(m1, m2 p2pcommon.PeerMeta) (eq bool) {
 func (pms *PeerMapService) unregisterPeer(peerID types.PeerID) {
 	pms.rwmutex.Lock()
 	defer pms.rwmutex.Unlock()
-	pms.Logger.Info().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("Unregistering bad peer")
+	pms.Logger.Info().Stringer(p2putil.LogPeerID, types.LogPeerShort(peerID)).Msg("Unregistering bad peer")
 	delete(pms.peerRegistry, peerID)
 }
 
@@ -551,10 +551,10 @@ func (pms *PeerMapService) checkConnectness(meta p2pcommon.PeerMeta) bool {
 	tempState := &peerState{PeerMapService: pms, meta: meta, addr: meta.ToPeerAddress(), lCheckTime: time.Now(), temporary: true}
 	_, err := tempState.checkConnect(PolarisPingTTL)
 	if err != nil {
-		pms.Logger.Debug().Err(err).Str(p2putil.LogPeerID, p2putil.ShortForm(meta.ID)).Msg("Ping check was failed.")
+		pms.Logger.Debug().Err(err).Stringer(p2putil.LogPeerID, types.LogPeerShort(meta.ID)).Msg("Ping check was failed.")
 		return false
 	} else {
-		pms.Logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(meta.ID)).Msg("Ping check is succeeded.")
+		pms.Logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(meta.ID)).Msg("Ping check is succeeded.")
 		return true
 	}
 }

--- a/polaris/server/peerstate.go
+++ b/polaris/server/peerstate.go
@@ -73,7 +73,7 @@ func (hc *peerState) check(wg *sync.WaitGroup, timeout time.Duration) {
 }
 
 func (hc *peerState) checkConnect(timeout time.Duration) (*types.Ping, error) {
-	hc.Logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(hc.meta.ID)).Msg("staring up healthcheck")
+	hc.Logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(hc.meta.ID)).Msg("staring up healthcheck")
 	hc.lCheckTime = time.Now()
 	s, err := hc.nt.GetOrCreateStreamWithTTL(hc.meta, PolarisPingTTL, common.PolarisPingSub)
 	if err != nil {
@@ -171,7 +171,7 @@ func (pc *pingChecker) DoCall(done chan<- interface{}) {
 		return
 	}
 
-	pc.Logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(pc.meta.ID)).Interface("ping_resp", pingResp).Msg("Healthcheck finished successful")
+	pc.Logger.Debug().Stringer(p2putil.LogPeerID, types.LogPeerShort(pc.meta.ID)).Interface("ping_resp", pingResp).Msg("Healthcheck finished successful")
 	return
 
 }

--- a/rpc/rpcstream.go
+++ b/rpc/rpcstream.go
@@ -115,7 +115,7 @@ SEND_LOOP:
 				if err != nil {
 					logger.Warn().Uint32("streamId", s.id).Err(err).Msg("failed to broadcast block metadata stream")
 				} else {
-					logger.Trace().Uint32("streamId", s.id).Object("hash", types.LogBase58{Bytes: &block.Hash}).Msg("broadcast new block metadata")
+					logger.Trace().Uint32("streamId", s.id).Stringer("hash", types.LogBase58(block.Hash)).Msg("broadcast new block metadata")
 				}
 			}
 		}

--- a/rpc/txputter.go
+++ b/rpc/txputter.go
@@ -110,7 +110,7 @@ func (m *txPutter) putToNextTx() int {
 		m.rs[m.offset] = &r
 		calculated := tx.CalculateTxHash()
 		if !bytes.Equal(hash, calculated) {
-			m.logger.Trace().Stringer("calculated", types.LogBase58(calculated)).Object("in", types.LogBase58(hash)).Msg("tx hash mismatch")
+			m.logger.Trace().Stringer("calculated", types.LogBase58(calculated)).Stringer("in", types.LogBase58(hash)).Msg("tx hash mismatch")
 			r.Error = types.CommitStatus_TX_INVALID_HASH
 		} else {
 			f := m.hub.RequestFuture(message.MemPoolSvc,

--- a/rpc/txputter.go
+++ b/rpc/txputter.go
@@ -110,7 +110,7 @@ func (m *txPutter) putToNextTx() int {
 		m.rs[m.offset] = &r
 		calculated := tx.CalculateTxHash()
 		if !bytes.Equal(hash, calculated) {
-			m.logger.Trace().Object("calculated", types.LogBase58{Bytes: &calculated}).Object("in", types.LogBase58{Bytes: &hash}).Msg("tx hash mismatch")
+			m.logger.Trace().Stringer("calculated", types.LogBase58(calculated)).Object("in", types.LogBase58(hash)).Msg("tx hash mismatch")
 			r.Error = types.CommitStatus_TX_INVALID_HASH
 		} else {
 			f := m.hub.RequestFuture(message.MemPoolSvc,

--- a/syncer/blockfetcher.go
+++ b/syncer/blockfetcher.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/rs/zerolog"
@@ -554,7 +553,7 @@ func (bf *BlockFetcher) findFinished(msg *message.GetBlockChunksRsp, peerMatch b
 			if task.isPeerMatched(msg.ToWhom) {
 				bf.runningQueue.Remove(e)
 
-				logger.Debug().Str("peer", p2putil.ShortForm(msg.ToWhom)).Err(msg.Err).Str("start", enc.ToString(task.hashes[0])).Int("count", task.count).Int("runqueue", bf.runningQueue.Len()).Msg("task finished with error")
+				logger.Debug().Stringer("peer", types.LogPeerShort(msg.ToWhom)).Err(msg.Err).Str("start", enc.ToString(task.hashes[0])).Int("count", task.count).Int("runqueue", bf.runningQueue.Len()).Msg("task finished with error")
 				return task, nil
 			}
 		} else {
@@ -655,7 +654,7 @@ func (ps *PeerSet) addNew(peerID types.PeerID) {
 	ps.pushFree(&SyncPeer{No: peerno, ID: peerID})
 	ps.total++
 
-	logger.Info().Str("peer", p2putil.ShortForm(peerID)).Int("peerno", peerno).Int("no", ps.total).Msg("new peer added")
+	logger.Info().Stringer("peer", types.LogPeerShort(peerID)).Int("peerno", peerno).Int("no", ps.total).Msg("new peer added")
 }
 
 /*

--- a/syncer/blockprocessor.go
+++ b/syncer/blockprocessor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aergoio/aergo/v2/chain"
 	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/types"
 )
@@ -78,13 +77,13 @@ func (bproc *BlockProcessor) isValidResponse(msg interface{}) error {
 		}
 
 		if blocks == nil || len(blocks) == 0 {
-			logger.Error().Err(msg.Err).Str("peer", p2putil.ShortForm(msg.ToWhom)).Msg("GetBlockChunksRsp is empty")
+			logger.Error().Err(msg.Err).Stringer("peer", types.LogPeerShort(msg.ToWhom)).Msg("GetBlockChunksRsp is empty")
 			return &ErrSyncMsg{msg: msg, str: "blocks is empty"}
 		}
 
 		for _, block := range blocks {
 			if prev != nil && !bytes.Equal(prev, block.GetHeader().GetPrevBlockHash()) {
-				logger.Error().Str("peer", p2putil.ShortForm(msg.ToWhom)).Msg("GetBlockChunksRsp hashes inconsistent")
+				logger.Error().Stringer("peer", types.LogPeerShort(msg.ToWhom)).Msg("GetBlockChunksRsp hashes inconsistent")
 				return &ErrSyncMsg{msg: msg, str: "blocks hash not matched"}
 			}
 
@@ -130,12 +129,12 @@ func (bproc *BlockProcessor) GetBlockChunkRsp(msg *message.GetBlockChunksRsp) er
 
 	bf := bproc.blockFetcher
 
-	logger.Debug().Str("peer", p2putil.ShortForm(msg.ToWhom)).Uint64("startNo", msg.Blocks[0].GetHeader().BlockNo).Int("count", len(msg.Blocks)).Msg("received GetBlockChunkRsp")
+	logger.Debug().Stringer("peer", types.LogPeerShort(msg.ToWhom)).Uint64("startNo", msg.Blocks[0].GetHeader().BlockNo).Int("count", len(msg.Blocks)).Msg("received GetBlockChunkRsp")
 
 	task, err := bf.findFinished(msg, false)
 	if err != nil {
 		//TODO invalid peer
-		logger.Error().Str("peer", p2putil.ShortForm(msg.ToWhom)).
+		logger.Error().Stringer("peer", types.LogPeerShort(msg.ToWhom)).
 			Int("count", len(msg.Blocks)).
 			Str("from", enc.ToString(msg.Blocks[0].GetHash())).
 			Str("to", enc.ToString(msg.Blocks[len(msg.Blocks)-1].GetHash())).
@@ -155,12 +154,12 @@ func (bproc *BlockProcessor) GetBlockChunkRsp(msg *message.GetBlockChunksRsp) er
 func (bproc *BlockProcessor) GetBlockChunkRspError(msg *message.GetBlockChunksRsp, err error) error {
 	bf := bproc.blockFetcher
 
-	logger.Error().Err(err).Str("peer", p2putil.ShortForm(msg.ToWhom)).Msg("receive GetBlockChunksRsp with error message")
+	logger.Error().Err(err).Stringer("peer", types.LogPeerShort(msg.ToWhom)).Msg("receive GetBlockChunksRsp with error message")
 
 	task, err := bf.findFinished(msg, true)
 	if err != nil {
 		//TODO invalid peer
-		logger.Error().Err(err).Str("peer", p2putil.ShortForm(msg.ToWhom)).Msg("dropped unknown block error message")
+		logger.Error().Err(err).Stringer("peer", types.LogPeerShort(msg.ToWhom)).Msg("dropped unknown block error message")
 		return nil
 	}
 

--- a/syncer/finder.go
+++ b/syncer/finder.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aergoio/aergo/v2/chain"
 	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/pkg/errors"
@@ -171,7 +170,7 @@ func (finder *Finder) getAnchors() ([][]byte, error) {
 
 func (finder *Finder) getAncestor(anchors [][]byte) (*types.BlockInfo, error) {
 	//	send remote Peer
-	logger.Debug().Str("peer", p2putil.ShortForm(finder.ctx.PeerID)).Msg("send GetAncestor message to peer")
+	logger.Debug().Stringer("peer", types.LogPeerShort(finder.ctx.PeerID)).Msg("send GetAncestor message to peer")
 	finder.compRequester.TellTo(message.P2PSvc, &message.GetSyncAncestor{Seq: finder.GetSeq(), ToWhom: finder.ctx.PeerID, Hashes: anchors})
 
 	timer := time.NewTimer(finder.dfltTimeout)

--- a/syncer/stubsyncer.go
+++ b/syncer/stubsyncer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aergoio/aergo-actor/actor"
 	"github.com/aergoio/aergo/v2/chain"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
@@ -212,9 +211,9 @@ func (syncer *StubSyncer) GetAnchors(msg *message.GetAnchors) {
 	go func() {
 		if syncer.cfg.debugContext.debugFinder {
 			if syncer.stubPeers[0].timeDelaySec > 0 {
-				logger.Debug().Str("peer", p2putil.ShortForm(types.PeerID(syncer.stubPeers[0].addr.PeerID))).Msg("slow target peer sleep")
+				logger.Debug().Stringer("peer", types.LogPeerShort(types.PeerID(syncer.stubPeers[0].addr.PeerID))).Msg("slow target peer sleep")
 				time.Sleep(syncer.stubPeers[0].timeDelaySec)
-				logger.Debug().Str("peer", p2putil.ShortForm(types.PeerID(syncer.stubPeers[0].addr.PeerID))).Msg("slow target peer wakeup")
+				logger.Debug().Stringer("peer", types.LogPeerShort(types.PeerID(syncer.stubPeers[0].addr.PeerID))).Msg("slow target peer wakeup")
 			}
 		}
 
@@ -274,9 +273,9 @@ func (syncer *StubSyncer) GetBlockChunks(msg *message.GetBlockChunks) {
 	}
 	go func() {
 		if stubPeer.timeDelaySec > 0 {
-			logger.Debug().Str("peer", p2putil.ShortForm(types.PeerID(stubPeer.addr.PeerID))).Msg("slow peer sleep")
+			logger.Debug().Stringer("peer", types.LogPeerShort(types.PeerID(stubPeer.addr.PeerID))).Msg("slow peer sleep")
 			time.Sleep(stubPeer.timeDelaySec)
-			logger.Debug().Str("peer", p2putil.ShortForm(types.PeerID(stubPeer.addr.PeerID))).Msg("slow peer wakeup")
+			logger.Debug().Stringer("peer", types.LogPeerShort(types.PeerID(stubPeer.addr.PeerID))).Msg("slow peer wakeup")
 		}
 
 		//send reply
@@ -305,7 +304,7 @@ func (syncer *StubSyncer) findStubPeer(peerID types.PeerID) *StubPeer {
 		}
 	}
 
-	logger.Error().Str("peer", p2putil.ShortForm(peerID)).Msg("can't find peer")
+	logger.Error().Stringer("peer", types.LogPeerShort(peerID)).Msg("can't find peer")
 	panic("peer find fail")
 }
 

--- a/syncer/syncerservice.go
+++ b/syncer/syncerservice.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aergoio/aergo/v2/chain"
 	cfg "github.com/aergoio/aergo/v2/config"
 	"github.com/aergoio/aergo/v2/message"
-	"github.com/aergoio/aergo/v2/p2p/p2putil"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/pkg/errors"
@@ -316,7 +315,7 @@ func (syncer *Syncer) handleSyncStart(msg *message.SyncStart) error {
 	var err error
 	var bestBlock *types.Block
 
-	logger.Debug().Uint64("targetNo", msg.TargetNo).Str("peer", p2putil.ShortForm(msg.PeerID)).Msg("syncer requested")
+	logger.Debug().Uint64("targetNo", msg.TargetNo).Stringer("peer", types.LogPeerShort(msg.PeerID)).Msg("syncer requested")
 
 	if syncer.isRunning {
 		logger.Debug().Uint64("targetNo", msg.TargetNo).Msg("skipped syncer is running")

--- a/tests/timeout/README
+++ b/tests/timeout/README
@@ -1,0 +1,8 @@
+This files is contract sources for testing timeout.
+
+The timeout test is not automated yet, and you should test it manually.
+
+1. build your own chain (make local private network)
+2. compile and deploy both callercontract.lua and longloop.lua
+3. call upgradeto of `callercontract` contract with param `longloop` contract
+4. call `justLoop` function on `longloop` , `invoke` and `directInvoke` on `callercontract` and watch log of aergo server or debug with IDE .

--- a/tests/timeout/callercontract.lua
+++ b/tests/timeout/callercontract.lua
@@ -1,0 +1,104 @@
+state.var {
+    _version = state.value(),
+    _implementation = state.value(),
+}
+
+-- A internal type check function
+-- @type internal
+-- @param x variable to check
+-- @param t (string) expected type
+local function _typecheck(x, t)
+    if (x and t == 'address') then
+      assert(type(x) == 'string', string.format("%s must be string type", t))
+      -- check address length
+      assert(52 == #x, string.format("invalid address length: %s (%s)", x, #x))
+      -- check character
+      local invalidChar = string.match(x, '[^123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]')
+      assert(nil == invalidChar, string.format("invalid address format: %s contains invalid char %s", x, invalidChar or 'nil'))
+    else
+      -- check default lua types
+      assert(type(x) == t, string.format("invalid type: %s != %s", type(x), t or 'nil'))
+    end
+end
+
+function _onlyProxyOwner()
+    assert(system.getCreator() == system.getSender(), string.format("only proxy owner. Owner: %s | sender: %s", system.getCreator(), system.getSender()))
+end
+
+-- Tells the address of the proxy owner
+-- @type query
+-- @return (address) The address of the proxy owner
+function proxyOwner()
+    return system.getCreator()
+end
+-- Allows the upgradeability owner to upgrade the current version of the proxy.
+-- @type call
+-- @param version (string) Representing the version name of the new implementation to be set.
+-- @param implementation (contractAddress) Representing the address of the new implementation to be set.
+-- @event Upgraded(version, implementation)
+function upgradeTo(version, implementation)
+    _onlyProxyOwner()
+    _upgradeTo(version, implementation)
+    contract.delegatecall(_implementation:get(), "init")
+end
+function _upgradeTo(version, implementation)
+    _typecheck(version, 'string')
+    _typecheck(implementation, 'address')
+    assert(system.isContract(implementation), string.format("[upgradeTo] invalid address format: %s", implementation))
+    assert(_implementation:get() ~= implementation, string.format("[upgradeTo] same implementation address %s", implementation))
+    _version:set(version)
+    _implementation:set(implementation)
+    contract.event("Upgraded", version, implementation)
+end
+
+-- Tells the version name of the current implementation
+-- @type query
+-- @return (string) Representing the name of the current version
+function version()
+    return _version:get()
+end
+-- Tells the address of the implementation where every call will be delegated.
+-- @type query
+-- @return (address) of the implementation to which it will be delegated
+function implementation()
+    return _implementation:get()
+end
+function default()
+end
+function invoke(callName, ...)
+    assert(nil ~= _implementation:get(), "implementation is nil")
+    if nil == callName then
+        callName = "default"
+    end
+    return contract.delegatecall(_implementation:get(), callName, ...)
+end
+
+-- Used to clearly show that it is a query-only
+function query(callName, ...)
+    assert(nil ~= _implementation:get(), "implementation is nil")
+    assert(nil ~= callName, "callName is nil")
+    return contract.delegatecall(_implementation:get(), callName, ...)
+end
+
+function directInvoke(callName, ...)
+    assert(nil ~= _implementation:get(), "implementation is nil")
+    if nil == callName then
+        callName = "default"
+    end
+    return contract.call(_implementation:get(), callName, ...)
+end
+
+-- Used to clearly show that it is a query-only
+function directQuery(callName, ...)
+    assert(nil ~= _implementation:get(), "implementation is nil")
+    assert(nil ~= callName, "callName is nil")
+    return contract.call(_implementation:get(), callName, ...)
+end
+
+function check_delegation(fname, ...)
+    return contract.delegatecall(_implementation:get(), "checkDelegation", ...)
+end
+
+abi.register(upgradeTo, invoke, directInvoke)
+abi.register_view(proxyOwner, version, implementation, query, directQuery)
+abi.fee_delegation(invoke, directInvoke)

--- a/tests/timeout/longloop.lua
+++ b/tests/timeout/longloop.lua
@@ -1,0 +1,32 @@
+-- state dbs
+state.var {
+    _t = state.value(), -- 의미없는 값
+}
+
+function init()
+    _t:set(0)
+end
+
+function justLoop(count)
+    local t = 0
+    while t < count do
+        t = t + 1
+        _t:set(t)
+    end
+    return t
+end
+
+function t()
+    return _t:get()
+end
+
+function catch(count)
+    return pcall(justLoop, count)
+end
+
+function contract_catch(count)
+    return contract.pcall(justLoop, count)
+end
+
+abi.register(init, justLoop, catch, contract_catch)
+abi.register_view(t)

--- a/tests/timeout/proxy.lua
+++ b/tests/timeout/proxy.lua
@@ -1,0 +1,130 @@
+-- A internal type check function
+-- @type internal
+-- @param x variable to check
+-- @param t (string) expected type
+local function _typecheck(x, t)
+    if (x and t == 'address') then
+      assert(type(x) == 'string', string.format("%s must be string type", t))
+      -- check address length
+      assert(52 == #x, string.format("invalid address length: %s (%s)", x, #x))
+      -- check character
+      local invalidChar = string.match(x, '[^123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]')
+      assert(nil == invalidChar, string.format("invalid address format: %s contains invalid char %s", x, invalidChar or 'nil'))
+    else
+      -- check default lua types
+      assert(type(x) == t, string.format("invalid type: %s != %s", type(x), t or 'nil'))
+    end
+end
+state.var {
+    _version = state.value(),
+    _implementation = state.value(),
+    _payableList = state.map(),
+    _payableArray = state.value()
+}
+function _onlyProxyOwner()
+    assert(system.getCreator() == system.getSender(), string.format("only proxy owner. Owner: %s | sender: %s", system.getCreator(), system.getSender()))
+end
+-- Tells the address of the proxy owner
+-- @type query
+-- @return (address) The address of the proxy owner
+function proxyOwner()
+    return system.getCreator()
+end
+-- Allows the upgradeability owner to upgrade the current version of the proxy.
+-- @type call
+-- @param version (string) Representing the version name of the new implementation to be set.
+-- @param implementation (contractAddress) Representing the address of the new implementation to be set.
+-- @event UpgradedPayableList()
+-- @event Upgraded(version, implementation)
+function upgradeTo(version, implementation, payableList)
+    _onlyProxyOwner()
+    _upgradePayableList(payableList)
+    _upgradeTo(version, implementation)
+    contract.delegatecall(_implementation:get(), "init")
+end
+function _upgradeTo(version, implementation)
+    _typecheck(version, 'string')
+    _typecheck(implementation, 'address')
+    assert(system.isContract(implementation), string.format("[upgradeTo] invalid address format: %s", implementation))
+    assert(_implementation:get() ~= implementation, string.format("[upgradeTo] same implementation address %s", implementation))
+    _version:set(version)
+    _implementation:set(implementation)
+    contract.event("Upgraded", version, implementation)
+end
+function _deletePayableList(oldList)
+    if nil ~= _payableArray:get() then
+        for i, payable in ipairs(oldList) do
+            _payableList:delete(payable)
+        end
+    end
+end
+function _setPayableList(newList)
+    _payableArray:set(newList)
+    if nil ~= newList then
+        for i, payable in ipairs(newList) do
+            _payableList[payable] = true
+        end
+    end
+end
+function _upgradePayableList(newList)
+    assert(nil == newList or 'table' == type(newList), "invalid payable list")
+    local oldList = _payableArray:get()
+    _deletePayableList(oldList)
+    _setPayableList(newList)
+    -- temporary commit
+    -- contract.event("UpgradedPayableList", oldList, newList)
+    contract.event("UpgradedPayableList")
+end
+function upgradePayableList(newList)
+    _onlyProxyOwner()
+    _upgradePayableList(newList)
+end
+function payableList()
+    return _payableArray:get()
+end
+function _isPayable(name)
+    return _payableList[name]
+end
+function refund(addr, amount)
+    _onlyProxyOwner()
+    _typecheck(addr, 'address')
+    contract.send(addr, amount)
+end
+-- Tells the version name of the current implementation
+-- @type query
+-- @return (string) Representing the name of the current version
+function version()
+    return _version:get()
+end
+-- Tells the address of the implementation where every call will be delegated.
+-- @type query
+-- @return (address) of the implementation to which it will be delegated
+function implementation()
+    return _implementation:get()
+end
+function default()
+end
+function invoke(callName, ...)
+    assert(nil ~= _implementation:get(), "implementation is nil")
+    if nil == callName then
+        callName = "default"
+    end
+    if not bignum.iszero(system.getAmount()) then
+        assert(_isPayable(callName), string.format("[%s] is not payable.", callName))
+    end
+    return contract.delegatecall(_implementation:get(), callName, ...)
+end
+-- Used to clearly show that it is a query-only
+function query(callName, ...)
+    assert(nil ~= _implementation:get(), "implementation is nil")
+    assert(nil ~= callName, "callName is nil")
+    return contract.delegatecall(_implementation:get(), callName, ...)
+end
+
+function check_delegation(fname, ...)
+    return contract.delegatecall(_implementation:get(), "checkDelegation", ...)
+end
+abi.register(upgradeTo, upgradePayableList, refund)
+abi.register_view(proxyOwner, version, implementation, payableList, query)
+abi.payable(default,invoke)
+abi.fee_delegation(invoke)

--- a/types/logging.go
+++ b/types/logging.go
@@ -60,10 +60,12 @@ func marshalTrx(tr Transaction, a *zerolog.Array) {
 	}
 }
 
-type LogBase58 struct {
-	Bytes *[]byte
+type LogBase58 []byte
+
+func (t LogBase58) String() string {
+	return enc.ToString(t)
 }
 
 func (t LogBase58) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("b58", enc.ToString(*t.Bytes))
+	e.Str("b58", enc.ToString(t))
 }

--- a/types/logging.go
+++ b/types/logging.go
@@ -59,10 +59,18 @@ func marshalTrx(tr Transaction, a *zerolog.Array) {
 	}
 }
 
+// LogBase58 is thin wrapper which show base58 encoded string of byte array
 type LogBase58 []byte
 
 func (t LogBase58) String() string {
 	return enc.ToString(t)
+}
+
+// LogAddr is thin wrapper which show base58 encoded form of wallet or smart contract
+type LogAddr Address
+
+func (t LogAddr) String() string {
+	return EncodeAddress(t)
 }
 
 type LogPeerShort PeerID

--- a/types/logging.go
+++ b/types/logging.go
@@ -7,7 +7,6 @@ package types
 
 import (
 	"fmt"
-
 	"github.com/aergoio/aergo/v2/internal/enc"
 	"github.com/rs/zerolog"
 )
@@ -66,6 +65,14 @@ func (t LogBase58) String() string {
 	return enc.ToString(t)
 }
 
-func (t LogBase58) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("b58", enc.ToString(t))
+type LogPeerShort PeerID
+
+func (t LogPeerShort) String() string {
+	// basically this function is same as function p2putils.ShortForm()
+	pretty := PeerID(t).Pretty()
+	if len(pretty) > 10 {
+		return fmt.Sprintf("%s*%s", pretty[:2], pretty[len(pretty)-6:])
+	} else {
+		return pretty
+	}
 }

--- a/types/logging_test.go
+++ b/types/logging_test.go
@@ -1,0 +1,97 @@
+package types
+
+import (
+	"github.com/aergoio/aergo-lib/log"
+	"github.com/aergoio/aergo/v2/internal/enc"
+	"github.com/rs/zerolog"
+	"testing"
+)
+
+func BenchmarkLogMemAllocationCompared(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := "sample"
+		logger.Warn().Int("idx", i).Str("var", sampleBytes).Msg("bench log")
+	}
+}
+
+func BenchmarkLogMemAllocation(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := []byte("sample")
+		logger.Warn().Int("idx", i).Str("var", EncodeB58(sampleBytes)).Msg("bench log")
+	}
+}
+func BenchmarkLogMemAllocationD(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := []byte("sample")
+		logger.Debug().Int("idx", i).Str("var", EncodeB58(sampleBytes)).Msg("bench log")
+	}
+}
+
+func BenchmarkLogMemAllocationRun(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := []byte("sample")
+		logger.Warn().Int("idx", i).Stringer("var", LogBase58(sampleBytes)).Msg("bench log")
+	}
+}
+
+func BenchmarkLogMemAllocationRunD(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := []byte("sample")
+		logger.Debug().Int("idx", i).Stringer("var", LogBase58(sampleBytes)).Msg("bench log")
+	}
+}
+
+type LogB58Wrapper []byte
+
+func (t LogB58Wrapper) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("b58", enc.ToString(t))
+}
+
+func BenchmarkLogMemAllocationWrapper(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := []byte("sample")
+		logger.Warn().Int("idx", i).Object("var", LogB58Wrapper(sampleBytes)).Msg("bench log")
+	}
+}
+
+func BenchmarkLogMemAllocationWrapperD(b *testing.B) {
+	type fields struct {
+		Bytes *[]byte
+	}
+	logger := log.NewLogger("benchmark.logger")
+
+	for i := 0; i < b.N; i++ {
+		sampleBytes := []byte("sample")
+		logger.Debug().Int("idx", i).Object("var", LogB58Wrapper(sampleBytes)).Msg("bench log")
+	}
+}


### PR DESCRIPTION
This patch fixes a bug that causes synchronization failure in situations when there are too many transactions.

There were two bugs, actually.

First, when creating a block, if the transaction execution timeout (1/4 of the block creation interval = 0.25 seconds) is reached, execution of the remaining transactions must be abandoned and a block must be created with only completed transactions, but the code does not work properly and the remaining transactions continue to be executed, so the block is created after a long time. I've changed the logic that checks timeout with one global channel variable to the logic that checks timeout by using `context.Context` created per a block.

Another problem was that when a timeout occurred during the execution of a transaction of multi-depth contract function - calling other contract inside function, the failed transaction should be abandoned and evicted, but added in the block due to a bug. The timeout is determined by real time and non-deterministic. That timeout transaction was executed as success on verification node, so that the block hash became different with block producer.