### PR TITLE
new functions for integration tests

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,4 +1,27 @@
 
+get_deploy_args() {
+  contract_file=$1
+  forkversion=$2
+
+  if [ "$fork_version" -ge "4" ]; then
+    deploy_args="$contract_file"
+  else
+    ../bin/aergoluac --payload $contract_file > payload.out
+    deploy_args="--payload `cat payload.out`"
+  fi
+
+}
+
+deploy() {
+
+  get_deploy_args $1 $2
+
+  txhash=$(../bin/aergocli --keystore . --password bmttest \
+    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
+    $deploy_args | jq .hash | sed 's/"//g')
+
+}
+
 get_receipt() {
   txhash=$1
   counter=0

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,7 +1,6 @@
 
 get_deploy_args() {
   contract_file=$1
-  forkversion=$2
 
   if [ "$fork_version" -ge "4" ]; then
     deploy_args="$contract_file"
@@ -14,7 +13,7 @@ get_deploy_args() {
 
 deploy() {
 
-  get_deploy_args $1 $2
+  get_deploy_args $1
 
   txhash=$(../bin/aergocli --keystore . --password bmttest \
     contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \

--- a/tests/test-gas-bf.sh
+++ b/tests/test-gas-bf.sh
@@ -6,11 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-../bin/aergoluac --payload ../contract/vm_dummy/test_files/gas_bf.lua > payload.out
-
-txhash=$(../bin/aergocli --keystore . --password bmttest \
-    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+deploy ../contract/vm_dummy/test_files/gas_bf.lua $fork_version
 
 get_receipt $txhash
 

--- a/tests/test-gas-bf.sh
+++ b/tests/test-gas-bf.sh
@@ -6,7 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-deploy ../contract/vm_dummy/test_files/gas_bf.lua $fork_version
+deploy ../contract/vm_dummy/test_files/gas_bf.lua
 
 get_receipt $txhash
 

--- a/tests/test-gas-deploy.sh
+++ b/tests/test-gas-deploy.sh
@@ -1,14 +1,12 @@
 set -e
 source common.sh
 
+fork_version=$1
+
 
 echo "-- deploy --"
 
-../bin/aergoluac --payload ../contract/vm_dummy/test_files/gas_deploy.lua > payload.out
-
-txhash=$(../bin/aergocli --keystore . --password bmttest \
-    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+deploy ../contract/vm_dummy/test_files/gas_deploy.lua $fork_version
 
 get_receipt $txhash
 

--- a/tests/test-gas-deploy.sh
+++ b/tests/test-gas-deploy.sh
@@ -6,7 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-deploy ../contract/vm_dummy/test_files/gas_deploy.lua $fork_version
+deploy ../contract/vm_dummy/test_files/gas_deploy.lua
 
 get_receipt $txhash
 

--- a/tests/test-gas-op.sh
+++ b/tests/test-gas-op.sh
@@ -6,7 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-deploy ../contract/vm_dummy/test_files/gas_op.lua $fork_version
+deploy ../contract/vm_dummy/test_files/gas_op.lua
 
 get_receipt $txhash
 

--- a/tests/test-gas-op.sh
+++ b/tests/test-gas-op.sh
@@ -1,14 +1,12 @@
 set -e
 source common.sh
 
+fork_version=$1
+
 
 echo "-- deploy --"
 
-../bin/aergoluac --payload ../contract/vm_dummy/test_files/gas_op.lua > payload.out
-
-txhash=$(../bin/aergocli --keystore . --password bmttest \
-    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+deploy ../contract/vm_dummy/test_files/gas_op.lua $fork_version
 
 get_receipt $txhash
 

--- a/tests/test-gas-per-function-v2.sh
+++ b/tests/test-gas-per-function-v2.sh
@@ -6,7 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-deploy ../contract/vm_dummy/test_files/gas_per_function.lua $fork_version
+deploy ../contract/vm_dummy/test_files/gas_per_function.lua
 
 get_receipt $txhash
 

--- a/tests/test-gas-per-function-v2.sh
+++ b/tests/test-gas-per-function-v2.sh
@@ -6,11 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-../bin/aergoluac --payload ../contract/vm_dummy/test_files/gas_per_function.lua > payload.out
-
-txhash=$(../bin/aergocli --keystore . --password bmttest \
-    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+deploy ../contract/vm_dummy/test_files/gas_per_function.lua $fork_version
 
 get_receipt $txhash
 

--- a/tests/test-gas-per-function-v3.sh
+++ b/tests/test-gas-per-function-v3.sh
@@ -6,7 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-deploy ../contract/vm_dummy/test_files/gas_per_function.lua $fork_version
+deploy ../contract/vm_dummy/test_files/gas_per_function.lua
 
 get_receipt $txhash
 

--- a/tests/test-gas-per-function-v3.sh
+++ b/tests/test-gas-per-function-v3.sh
@@ -6,11 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-../bin/aergoluac --payload ../contract/vm_dummy/test_files/gas_per_function.lua > payload.out
-
-txhash=$(../bin/aergocli --keystore . --password bmttest \
-    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+deploy ../contract/vm_dummy/test_files/gas_per_function.lua $fork_version
 
 get_receipt $txhash
 

--- a/tests/test-gas-verify-proof.sh
+++ b/tests/test-gas-verify-proof.sh
@@ -6,7 +6,7 @@ fork_version=$1
 
 echo "-- deploy --"
 
-deploy ../contract/vm_dummy/test_files/feature_luacryptoverifyproof.lua $fork_version
+deploy ../contract/vm_dummy/test_files/feature_luacryptoverifyproof.lua
 
 get_receipt $txhash
 

--- a/tests/test-gas-verify-proof.sh
+++ b/tests/test-gas-verify-proof.sh
@@ -1,14 +1,12 @@
 set -e
 source common.sh
 
+fork_version=$1
+
 
 echo "-- deploy --"
 
-../bin/aergoluac --payload ../contract/vm_dummy/test_files/feature_luacryptoverifyproof.lua > payload.out
-
-txhash=$(../bin/aergocli --keystore . --password bmttest \
-    contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+deploy ../contract/vm_dummy/test_files/feature_luacryptoverifyproof.lua $fork_version
 
 get_receipt $txhash
 

--- a/tests/test-max-call-depth.sh
+++ b/tests/test-max-call-depth.sh
@@ -1,6 +1,8 @@
 set -e
 source common.sh
 
+fork_version=$1
+
 
 # deploy 66 identical contracts using test-max-call-depth-2.lua
 # and store the returned addresses in an array
@@ -13,13 +15,13 @@ declare -a addresses
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-../bin/aergoluac --payload test-max-call-depth-2.lua > payload.out
+get_deploy_args test-max-call-depth-2.lua $fork_version
 
 for i in {1..66}
 do
   txhash=$(../bin/aergocli --keystore . --password bmttest --nonce $(($nonce+$i)) \
     contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+    $deploy_args | jq .hash | sed 's/"//g')
 
   txhashes[$i]=$txhash
 done
@@ -136,7 +138,7 @@ echo "-- deploy 66 contracts --"
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-../bin/aergoluac --payload test-max-call-depth-3.lua > payload.out
+get_deploy_args test-max-call-depth-3.lua $fork_version
 
 declare -a txhashes
 declare -a addresses
@@ -145,7 +147,7 @@ for i in {1..66}
 do
   txhash=$(../bin/aergocli --keystore . --password bmttest --nonce $(($nonce+$i)) \
     contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+    $deploy_args | jq .hash | sed 's/"//g')
 
   txhashes[$i]=$txhash
 done
@@ -279,7 +281,7 @@ echo "-- deploy 4 contracts --"
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-../bin/aergoluac --payload test-max-call-depth-2.lua > payload.out
+get_deploy_args test-max-call-depth-2.lua $fork_version
 
 declare -a txhashes
 declare -a addresses
@@ -288,7 +290,7 @@ for i in {1..4}
 do
   txhash=$(../bin/aergocli --keystore . --password bmttest --nonce $(($nonce+$i)) \
     contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+    $deploy_args | jq .hash | sed 's/"//g')
 
   txhashes[$i]=$txhash
 done
@@ -417,7 +419,7 @@ echo "-- deploy 2 contracts --"
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-../bin/aergoluac --payload test-max-call-depth-2.lua > payload.out
+get_deploy_args test-max-call-depth-2.lua $fork_version
 
 declare -a txhashes
 declare -a addresses
@@ -426,7 +428,7 @@ for i in {1..2}
 do
   txhash=$(../bin/aergocli --keystore . --password bmttest --nonce $(($nonce+$i)) \
     contract deploy AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R \
-    --payload `cat payload.out` | jq .hash | sed 's/"//g')
+    $deploy_args | jq .hash | sed 's/"//g')
 
   txhashes[$i]=$txhash
 done

--- a/tests/test-max-call-depth.sh
+++ b/tests/test-max-call-depth.sh
@@ -15,7 +15,7 @@ declare -a addresses
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-get_deploy_args test-max-call-depth-2.lua $fork_version
+get_deploy_args test-max-call-depth-2.lua
 
 for i in {1..66}
 do
@@ -138,7 +138,7 @@ echo "-- deploy 66 contracts --"
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-get_deploy_args test-max-call-depth-3.lua $fork_version
+get_deploy_args test-max-call-depth-3.lua
 
 declare -a txhashes
 declare -a addresses
@@ -281,7 +281,7 @@ echo "-- deploy 4 contracts --"
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-get_deploy_args test-max-call-depth-2.lua $fork_version
+get_deploy_args test-max-call-depth-2.lua
 
 declare -a txhashes
 declare -a addresses
@@ -419,7 +419,7 @@ echo "-- deploy 2 contracts --"
 account_state=$(../bin/aergocli getstate --address AmPpcKvToDCUkhT1FJjdbNvR4kNDhLFJGHkSqfjWe3QmHm96qv4R)
 nonce=$(echo $account_state | jq .nonce | sed 's/"//g')
 
-get_deploy_args test-max-call-depth-2.lua $fork_version
+get_deploy_args test-max-call-depth-2.lua
 
 declare -a txhashes
 declare -a addresses


### PR DESCRIPTION
`aergocli` will work differently if deploying for <= V3 or >= V4

These new functions prepare the integration tests for new deploy method on #266

Although this is focused on changes to be applied only on V4, the changes here are backwards compatible and it is useful to merge them before so other work made on integration tests can use these new functions