### PR TITLE
config: use relative path for npkey

### DIFF
--- a/p2p/p2pkey/nodekey.go
+++ b/p2p/p2pkey/nodekey.go
@@ -46,7 +46,11 @@ func InitNodeInfo(baseCfg *config.BaseConfig, p2pCfg *config.P2PConfig, version 
 	}
 
 	if p2pCfg.NPKey != "" {
-		priv, pub, err = p2putil.LoadKeyFile(p2pCfg.NPKey)
+		NPKeyFilePath := p2pCfg.NPKey
+		if len(NPKeyFilePath) > 0 && NPKeyFilePath[0] != '/' && NPKeyFilePath[0] != '.' {
+			NPKeyFilePath = filepath.Join(baseCfg.AuthDir, NPKeyFilePath)
+		}
+		priv, pub, err = p2putil.LoadKeyFile(NPKeyFilePath)
 		if err != nil {
 			panic("Failed to load Keyfile '" + p2pCfg.NPKey + "' " + err.Error())
 		}


### PR DESCRIPTION
In the `[p2p]` section of the `config.toml` the `npkey` appears to be using only full paths

This PR changes the code to work like this:

If there is no "/" and no "." at the beginning of `npkey` (no full path specified) then prepend the path of the `auth` folder to it

So a config like this:

```
npkey = "bp01.key"
```

Expects the `bp01.key` to be inside the `auth` folder

I don't know if this is the best approach

Please leave your opinion