### PR TITLE
fix wrong block generation inverval in raft

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -69,6 +69,8 @@ type Consensus interface {
 	ChainConsensus
 	ConsensusAccessor
 	Ticker() *time.Ticker
+	// QueueJob queues block generation job.
+	// It waits until next block generation time is reached in raft consensus and sbp.
 	QueueJob(now time.Time, jq chan<- interface{})
 	BlockFactory() BlockFactory
 	QuitChan() chan interface{}

--- a/consensus/impl/raftv2/blockfactory.go
+++ b/consensus/impl/raftv2/blockfactory.go
@@ -237,7 +237,7 @@ func (bf *BlockFactory) Ticker() *time.Ticker {
 	return time.NewTicker(BlockFactoryTickMs)
 }
 
-// QueueJob send a block triggering information to jq.
+// QueueJob send a block triggering information to jq, and hold to wait
 func (bf *BlockFactory) QueueJob(now time.Time, jq chan<- interface{}) {
 	bf.jobLock.Lock()
 	defer bf.jobLock.Unlock()
@@ -279,6 +279,7 @@ func (bf *BlockFactory) QueueJob(now time.Time, jq chan<- interface{}) {
 
 		logger.Debug().Str("work", work.ToString()).Str("prev", prevToString(prev)).Msg("new work generated")
 		jq <- work
+		time.Sleep(BlockIntervalMs)
 	}
 }
 

--- a/consensus/impl/sbp/sbp.go
+++ b/consensus/impl/sbp/sbp.go
@@ -45,7 +45,7 @@ func (te *txExec) Apply(bState *state.BlockState, tx types.Transaction) error {
 	return err
 }
 
-// SimpleBlockFactory implments a simple block factory which generate block each cfg.Consensus.BlockInterval.
+// SimpleBlockFactory implements a simple block factory which generate block each cfg.Consensus.BlockInterval.
 //
 // This can be used for testing purpose.
 type SimpleBlockFactory struct {
@@ -118,6 +118,7 @@ func (s *SimpleBlockFactory) QueueJob(now time.Time, jq chan<- interface{}) {
 		}
 		s.prevBlock = b
 		jq <- b
+		time.Sleep(s.blockInterval)
 	}
 }
 


### PR DESCRIPTION
It fix bug that the blocks are generated too much in raft consensus. 
It preserve behavior of v2.4.7 at best effort.