### PR TITLE
rollback contract state on failed pcall

### DIFF
--- a/contract/contract_module.c
+++ b/contract/contract_module.c
@@ -27,10 +27,12 @@ static void reset_amount_info (lua_State *L) {
 }
 
 static int set_value(lua_State *L, const char *str) {
+
 	set_call_obj(L, str);
 	if (lua_isnil(L, 1)) {
 		return 1;
 	}
+
 	switch(lua_type(L, 1)) {
 	case LUA_TNUMBER: {
 		const char *str = lua_tostring(L, 1);
@@ -52,6 +54,7 @@ static int set_value(lua_State *L, const char *str) {
 	default:
 		luaL_error(L, "invalid input");
 	}
+
 	lua_setfield(L, -2, amount_str);
 
 	return 1;
@@ -296,14 +299,18 @@ static int modulePcall(lua_State *L) {
 	}
 
 	if ((ret = lua_pcall(L, argc, LUA_MULTRET, 0)) != 0) {
+		// if out of memory, throw error
 		if (ret == LUA_ERRMEM) {
 			luaL_throwerror(L);
 		}
+		// add 'success = false' as the first returned value
 		lua_pushboolean(L, false);
 		lua_insert(L, 1);
+		// drop the events
 		if (vm_is_hardfork(L, 4)) {
 			luaDropEvent(L, service, num_events);
 		}
+		// revert the contract state
 		if (start_seq.r0 > 0) {
 			char *errStr = luaClearRecovery(L, service, start_seq.r0, true);
 			if (errStr != NULL) {
@@ -313,8 +320,12 @@ static int modulePcall(lua_State *L) {
 		}
 		return 2;
 	}
+
+	// add 'success = true' as the first returned value
 	lua_pushboolean(L, true);
 	lua_insert(L, 1);
+
+	// release the recovery point
 	if (start_seq.r0 == 1) {
 		char *errStr = luaClearRecovery(L, service, start_seq.r0, false);
 		if (errStr != NULL) {
@@ -325,6 +336,8 @@ static int modulePcall(lua_State *L) {
 			luaL_throwerror(L);
 		}
 	}
+
+	// return the number of items in the stack
 	return lua_gettop(L);
 }
 
@@ -342,6 +355,7 @@ static int moduleDeploy(lua_State *L) {
 
 	lua_gasuse(L, 5000);
 
+	// get the amount to transfer to the new contract
 	lua_getfield(L, 1, amount_str);
 	if (lua_isnil(L, -1)) {
 		amount = NULL;
@@ -349,7 +363,9 @@ static int moduleDeploy(lua_State *L) {
 		amount = (char *) luaL_checkstring(L, -1);
 	}
 	lua_pop(L, 1);
+	// get the contract source code or the address to an existing contract
 	contract = (char *) luaL_checkstring(L, 2);
+	// get the deploy arguments to the constructor function
 	json_args = lua_util_get_json_from_stack(L, 3, lua_gettop(L), false);
 	if (json_args == NULL) {
 		reset_amount_info(L);
@@ -363,13 +379,13 @@ static int moduleDeploy(lua_State *L) {
 		strPushAndRelease(L, ret.r1);
 		luaL_throwerror(L);
 	}
+
 	free(json_args);
 	reset_amount_info(L);
 	strPushAndRelease(L, ret.r1);
 	if (ret.r0 > 1) {
 		lua_insert(L, -ret.r0);
 	}
-
 	return ret.r0;
 }
 

--- a/contract/vm.c
+++ b/contract/vm.c
@@ -71,7 +71,7 @@ static void preloadModules(lua_State *L) {
 // overridden version of pcall
 // used to rollback state and drop events upon error
 static int pcall(lua_State *L) {
-	int argc = lua_gettop(L) - 1;
+	int argc = lua_gettop(L);
 	int service = getLuaExecContext(L);
 	int num_events = luaGetEventCount(L, service);
 	struct luaSetRecoveryPoint_return start_seq;
@@ -93,7 +93,7 @@ static int pcall(lua_State *L) {
 	//   func arg1 arg2 ... argn
 
 	// call the function
-	ret = lua_pcall(L, argc, LUA_MULTRET, 0);
+	ret = lua_pcall(L, argc - 1, LUA_MULTRET, 0);
 
 	// if failed, drop the events
 	if (ret != 0) {
@@ -131,7 +131,7 @@ static int pcall(lua_State *L) {
 // overridden version of xpcall
 // used to rollback state and drop events upon error
 static int xpcall(lua_State *L) {
-	int argc = lua_gettop(L) - 1;
+	int argc = lua_gettop(L);
 	int service = getLuaExecContext(L);
 	int num_events = luaGetEventCount(L, service);
 	struct luaSetRecoveryPoint_return start_seq;
@@ -171,7 +171,7 @@ static int xpcall(lua_State *L) {
 	errfunc = 1;
 
 	// call the function
-	ret = lua_pcall(L, argc - 1, LUA_MULTRET, errfunc);
+	ret = lua_pcall(L, argc - 2, LUA_MULTRET, errfunc);
 
 	// if failed, drop the events
 	if (ret != 0) {

--- a/contract/vm.c
+++ b/contract/vm.c
@@ -68,56 +68,85 @@ static void preloadModules(lua_State *L) {
 #endif
 }
 
-/* override pcall to drop events upon error */
+// overridden version of pcall
+// used to rollback state and drop events upon error
 static int pcall(lua_State *L) {
-	int argc = lua_gettop(L);
-	int status;
-
-	// get the current number of events
+	int argc = lua_gettop(L) - 1;
 	int service = getLuaExecContext(L);
 	int num_events = luaGetEventCount(L, service);
+	struct luaSetRecoveryPoint_return start_seq;
+	int ret;
 
 	if (argc < 1) {
 		return luaL_error(L, "pcall: not enough arguments");
+	}
+
+	lua_gasuse(L, 300);
+
+	start_seq = luaSetRecoveryPoint(L, service);
+	if (start_seq.r0 < 0) {
+		strPushAndRelease(L, start_seq.r1);
+		luaL_throwerror(L);
 	}
 
 	// the stack is like this:
 	//   func arg1 arg2 ... argn
 
 	// call the function
-	status = lua_pcall(L, argc - 1, LUA_MULTRET, 0);
+	ret = lua_pcall(L, argc, LUA_MULTRET, 0);
 
 	// if failed, drop the events
-	if (status != 0) {
+	if (ret != 0) {
 		if (vm_is_hardfork(L, 4)) {
 			luaDropEvent(L, service, num_events);
 		}
 	}
 
 	// throw the error if out of memory
-	if (status == LUA_ERRMEM) {
+	if (ret == LUA_ERRMEM) {
 		luaL_throwerror(L);
 	}
 
 	// insert the status at the bottom of the stack
-	lua_pushboolean(L, status == 0);
+	lua_pushboolean(L, ret == 0);
 	lua_insert(L, 1);
+
+	// release the recovery point or revert the contract state
+	if (start_seq.r0 > 0) {
+		bool is_error = (ret != 0);
+		char *errStr = luaClearRecovery(L, service, start_seq.r0, is_error);
+		if (errStr != NULL) {
+			if (vm_is_hardfork(L, 4)) {
+				luaDropEvent(L, service, num_events);
+			}
+			strPushAndRelease(L, errStr);
+			luaL_throwerror(L);
+		}
+	}
 
 	// return the number of items in the stack
 	return lua_gettop(L);
 }
 
+// overridden version of xpcall
+// used to rollback state and drop events upon error
 static int xpcall(lua_State *L) {
-	int argc = lua_gettop(L);
-	int errfunc;
-	int status;
-
-	// get the current number of events
+	int argc = lua_gettop(L) - 1;
 	int service = getLuaExecContext(L);
 	int num_events = luaGetEventCount(L, service);
+	struct luaSetRecoveryPoint_return start_seq;
+	int ret, errfunc;
 
 	if (argc < 2) {
 		return luaL_error(L, "xpcall: not enough arguments");
+	}
+
+	lua_gasuse(L, 300);
+
+	start_seq = luaSetRecoveryPoint(L, service);
+	if (start_seq.r0 < 0) {
+		strPushAndRelease(L, start_seq.r1);
+		luaL_throwerror(L);
 	}
 
 	// the stack is like this:
@@ -142,17 +171,17 @@ static int xpcall(lua_State *L) {
 	errfunc = 1;
 
 	// call the function
-	status = lua_pcall(L, argc - 2, LUA_MULTRET, errfunc);
+	ret = lua_pcall(L, argc - 1, LUA_MULTRET, errfunc);
 
 	// if failed, drop the events
-	if (status != 0) {
+	if (ret != 0) {
 		if (vm_is_hardfork(L, 4)) {
 			luaDropEvent(L, service, num_events);
 		}
 	}
 
 	// throw the error if out of memory
-	if (status == LUA_ERRMEM) {
+	if (ret == LUA_ERRMEM) {
 		luaL_throwerror(L);
 	}
 
@@ -166,8 +195,21 @@ static int xpcall(lua_State *L) {
 	}
 
 	// store the status at the bottom of the stack, replacing the error handler
-	lua_pushboolean(L, status == 0);
+	lua_pushboolean(L, ret == 0);
 	lua_replace(L, 1);
+
+	// release the recovery point or revert the contract state
+	if (start_seq.r0 > 0) {
+		bool is_error = (ret != 0);
+		char *errStr = luaClearRecovery(L, service, start_seq.r0, is_error);
+		if (errStr != NULL) {
+			if (vm_is_hardfork(L, 4)) {
+				luaDropEvent(L, service, num_events);
+			}
+			strPushAndRelease(L, errStr);
+			luaL_throwerror(L);
+		}
+	}
 
 	// return the number of items in the stack
 	return lua_gettop(L);

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -1370,6 +1370,8 @@ func GetABI(contractState *state.ContractState, bs *state.BlockState) (*types.AB
 func (re *recoveryEntry) recovery(bs *state.BlockState) error {
 	var zero big.Int
 	cs := re.callState
+
+	// restore the contract balance
 	if re.amount.Cmp(&zero) > 0 {
 		if re.senderState != nil {
 			re.senderState.Balance = new(big.Int).Add(re.senderState.GetBalanceBigInt(), re.amount).Bytes()
@@ -1381,6 +1383,8 @@ func (re *recoveryEntry) recovery(bs *state.BlockState) error {
 	if re.onlySend {
 		return nil
 	}
+
+	// restore the contract nonce
 	if re.senderState != nil {
 		re.senderState.Nonce = re.senderNonce
 	}
@@ -1388,6 +1392,8 @@ func (re *recoveryEntry) recovery(bs *state.BlockState) error {
 	if cs == nil {
 		return nil
 	}
+
+	// restore the contract state
 	if re.stateRevision != -1 {
 		err := cs.ctrState.Rollback(re.stateRevision)
 		if err != nil {
@@ -1401,6 +1407,8 @@ func (re *recoveryEntry) recovery(bs *state.BlockState) error {
 			bs.RemoveCache(cs.ctrState.GetAccountID())
 		}
 	}
+
+	// restore the contract SQL db state
 	if cs.tx != nil {
 		if re.sqlSaveName == nil {
 			err := cs.tx.rollbackToSavepoint()
@@ -1415,6 +1423,7 @@ func (re *recoveryEntry) recovery(bs *state.BlockState) error {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/contract/vm_dummy/vm_dummy_test.go
+++ b/contract/vm_dummy/vm_dummy_test.go
@@ -1230,17 +1230,47 @@ func TestSqlOnConflict(t *testing.T) {
 
 		err = bc.ConnectBlock(
 			NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec", "args": ["insert into t values (5)"]}`),
-			NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec", "args": ["insert or rollback into t values (5)"]}`).Fail("syntax error"),
+			NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec", "args": ["insert or rollback into t values (6),(5),(7)"]}`).Fail("syntax error"),
 		)
 		require.NoErrorf(t, err, "failed to call tx")
 
 		err = bc.Query("on_conflict", `{"name":"get"}`, "", `[1,2,3,4,5]`)
 		require.NoErrorf(t, err, "failed to query")
 
-		err = bc.ConnectBlock(NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec_pcall", "args": ["insert or fail into t values (6),(7),(5),(8),(9)"]}`))
+		err = bc.ConnectBlock(NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec", "args": ["insert or abort into t values (6),(7),(5),(8),(9)"]}`).Fail("UNIQUE constraint failed"))
 		require.NoErrorf(t, err, "failed to call tx")
 
-		err = bc.Query("on_conflict", `{"name":"get"}`, "", `[1,2,3,4,5,6,7]`)
+		err = bc.Query("on_conflict", `{"name":"get"}`, "", `[1,2,3,4,5]`)
+		require.NoErrorf(t, err, "failed to query")
+
+		// successful pcall
+		err = bc.ConnectBlock(NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec_pcall", "args": ["insert into t values (6)"]}`))
+		require.NoErrorf(t, err, "failed to call tx")
+
+		err = bc.Query("on_conflict", `{"name":"get"}`, "", `[1,2,3,4,5,6]`)
+		require.NoErrorf(t, err, "failed to query")
+
+		// pcall fails but the tx succeeds
+		err = bc.ConnectBlock(NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec_pcall", "args": ["insert or fail into t values (7),(5),(8)"]}`))
+		require.NoErrorf(t, err, "failed to call tx")
+
+		var expected string
+		if version >= 4 {
+			// pcall reverts the changes
+			expected = `[1,2,3,4,5,6]`
+		} else {
+			// pcall does not revert the changes
+			expected = `[1,2,3,4,5,6,7]`
+		}
+
+		err = bc.Query("on_conflict", `{"name":"get"}`, "", expected)
+		require.NoErrorf(t, err, "failed to query")
+
+		// here the tx is reverted
+		err = bc.ConnectBlock(NewLuaTxCall("user1", "on_conflict", 0, `{"name":"stmt_exec", "args": ["insert or fail into t values (7),(5),(8)"]}`).Fail("UNIQUE constraint failed"))
+		require.NoErrorf(t, err, "failed to call tx")
+
+		err = bc.Query("on_conflict", `{"name":"get"}`, "", expected)
 		require.NoErrorf(t, err, "failed to query")
 
 	}


### PR DESCRIPTION
This makes the `pcall` and `xpcall` rollback the contract state (state variables, nonce, balance, sql db) when the called function fails

The PR is built on top of #199 and it is made to be merged into it first, if approved

It is made into a separate PR in order to discuss if this is a bug-fix, what is the expected behavior of these functions, and if backwards compatibility is required