### PR TITLE
Fix occasional failure of unit test

### DIFF
--- a/consensus/impl/dpos/blockfactory_test.go
+++ b/consensus/impl/dpos/blockfactory_test.go
@@ -21,11 +21,11 @@ func TestBlockFactory_context(t *testing.T) {
 	select {
 	case <-timeoutCtx.Done():
 		err := timeoutCtx.Err()
-		assert.Equal(t, context.DeadlineExceeded, err, "err by deadline")
+		assert.Equal(t, context.DeadlineExceeded, err, "unexpected error type")
 		// check if timeout occured not before deadline
 		assert.True(t, time.Now().After(contextDeadline))
-	case <-time.NewTimer(time.Second * 5).C:
-		assert.Fail(t, "deadline expected, but not")
+	case <-time.NewTimer(5 * time.Second).C:
+		assert.Fail(t, "timeout did not occur within expected time frame")
 	}
 
 	// second channel is canceled by self cancel func
@@ -33,7 +33,7 @@ func TestBlockFactory_context(t *testing.T) {
 	select {
 	case <-cancelCtx.Done():
 		err := cancelCtx.Err()
-		assert.Equalf(t, context.Canceled, err, "err by cancel")
+		assert.Equalf(t, context.Canceled, err, "unexpected error type")
 		//assert.Equal(t, err, context.Cause(cancelCtx), "cause and err is differ")
 	default:
 		assert.Fail(t, "cancel expected, but not")
@@ -42,12 +42,12 @@ func TestBlockFactory_context(t *testing.T) {
 	// third channel is canceled by parent with cause
 	close(quitC)
 	<-factory.ctx.Done()
-	assert.Equal(t, context.Canceled, factory.ctx.Err(), "factory err ErrQuit expected")
+	assert.Equal(t, context.Canceled, factory.ctx.Err(), "unexpected error type")
 	//assert.Equal(t, chain.ErrQuit, context.Cause(factory.ctx), "factory cause ErrQuit expected")
 	select {
 	case <-quitCtx.Done():
 		err := quitCtx.Err()
-		assert.Equalf(t, context.Canceled, err, "err by quit")
+		assert.Equalf(t, context.Canceled, err, "unexpected error type")
 		//assert.Equal(t, chain.ErrQuit, context.Cause(quitCtx), "cause ErrQuit expected")
 	default:
 		assert.Fail(t, "errQuit expected, but not")

--- a/consensus/impl/dpos/blockfactory_test.go
+++ b/consensus/impl/dpos/blockfactory_test.go
@@ -13,17 +13,18 @@ func TestBlockFactory_context(t *testing.T) {
 	factory.initContext()
 
 	timeoutCtx, _ := context.WithTimeout(factory.ctx, time.Millisecond)
+	contextDeadline, _ := timeoutCtx.Deadline()
 	cancelCtx, cancelFunc := context.WithTimeout(factory.ctx, time.Minute)
 	quitCtx, _ := context.WithTimeout(factory.ctx, time.Minute)
-	time.Sleep(time.Millisecond * time.Duration(2))
 
 	// first channel is done by deadline
 	select {
 	case <-timeoutCtx.Done():
 		err := timeoutCtx.Err()
 		assert.Equal(t, context.DeadlineExceeded, err, "err by deadline")
-		//assert.Equal(t, err, context.Cause(timeoutCtx), "cause and err is differ")
-	default:
+		// check if timeout occured not before deadline
+		assert.True(t, time.Now().After(contextDeadline))
+	case <-time.NewTimer(time.Second * 5).C:
 		assert.Fail(t, "deadline expected, but not")
 	}
 


### PR DESCRIPTION
This test was sometimes failed by timing issue, such like in heavy load in host machine of container.