### PR TITLE
refactor state

### DIFF
--- a/account/accountservice.go
+++ b/account/accountservice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aergoio/aergo/v2/contract/name"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/message"
 )
@@ -63,7 +64,7 @@ func (as *AccountService) Statistics() *map[string]interface{} {
 	}
 }
 func (as *AccountService) resolveName(namedAddress []byte) ([]byte, error) {
-	scs, err := state.GetNameAccountState(as.sdb.GetStateDB())
+	scs, err := statedb.GetNameAccountState(as.sdb.GetStateDB())
 	if err != nil {
 		return nil, err
 	}

--- a/chain/chainhandle.go
+++ b/chain/chainhandle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/internal/enc/proto"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/message"
 )
@@ -958,8 +959,8 @@ func executeTx(execCtx context.Context, ccc consensus.ChainConsensusCluster, cdb
 			return err
 		}
 
-		var contractState *state.ContractState
-		contractState, err = state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
+		var contractState *statedb.ContractState
+		contractState, err = statedb.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 		if err != nil {
 			return err
 		}

--- a/chain/chainhandle.go
+++ b/chain/chainhandle.go
@@ -959,7 +959,7 @@ func executeTx(execCtx context.Context, ccc consensus.ChainConsensusCluster, cdb
 		}
 
 		var contractState *state.ContractState
-		contractState, err = state.OpenContractState(receiver.AccountID(), receiver.State(), bs.StateDB)
+		contractState, err = state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 		if err != nil {
 			return err
 		}

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -295,7 +295,7 @@ func NewChainService(cfg *cfg.Config) *ChainService {
 	types.InitGovernance(cs.ConsensusType(), cs.IsPublic())
 
 	//reset parameter of aergo.system
-	systemState, err := cs.SDB().GetSystemAccountState()
+	systemState, err := statedb.GetSystemAccountState(cs.SDB().GetStateDB())
 	if err != nil {
 		logger.Panic().Err(err).Msg("failed to read aergo.system state")
 	}

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -800,7 +800,7 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 			})
 			break
 		}
-		contractState, err := state.OpenContractStateAccount(types.ToAccountID(address), sdb)
+		contractState, err := state.OpenContractStateAccount(address, sdb)
 		if err == nil {
 			abi, err := contract.GetABI(contractState, nil)
 			context.Respond(message.GetABIRsp{
@@ -822,7 +822,7 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 			context.Respond(message.GetQueryRsp{Result: nil, Err: err})
 			break
 		}
-		ctrState, err := state.OpenContractStateAccount(types.ToAccountID(address), sdb)
+		ctrState, err := state.OpenContractStateAccount(address, sdb)
 		if err != nil {
 			logger.Error().Str("hash", base58.Encode(address)).Err(err).Msg("failed to get state for contract")
 			context.Respond(message.GetQueryRsp{Result: nil, Err: err})
@@ -910,7 +910,7 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 		defer runtime.UnlockOSThread()
 
 		sdb = cw.sdb.OpenNewStateDB(cw.sdb.GetRoot())
-		ctrState, err := state.OpenContractStateAccount(types.ToAccountID(msg.Contract), sdb)
+		ctrState, err := state.OpenContractStateAccount(msg.Contract, sdb)
 		if err != nil {
 			logger.Error().Str("hash", base58.Encode(msg.Contract)).Err(err).Msg("failed to get state for contract")
 			context.Respond(message.CheckFeeDelegationRsp{Err: err})

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -496,7 +496,7 @@ func (cs *ChainService) getVotes(id string, n uint32) (*types.VoteList, error) {
 	switch ConsensusName() {
 	case consensus.ConsensusName[consensus.ConsensusDPOS]:
 		sdb := cs.sdb.OpenNewStateDB(cs.sdb.GetRoot())
-		scs, err := state.GetSystemAccountState(sdb)
+		scs, err := statedb.GetSystemAccountState(sdb)
 		if err != nil {
 			return nil, err
 		}
@@ -518,11 +518,11 @@ func (cs *ChainService) getAccountVote(addr []byte) (*types.AccountVoteInfo, err
 	}
 
 	sdb := cs.sdb.OpenNewStateDB(cs.sdb.GetRoot())
-	scs, err := state.GetSystemAccountState(sdb)
+	scs, err := statedb.GetSystemAccountState(sdb)
 	if err != nil {
 		return nil, err
 	}
-	namescs, err := state.GetNameAccountState(sdb)
+	namescs, err := statedb.GetNameAccountState(sdb)
 	if err != nil {
 		return nil, err
 	}
@@ -540,11 +540,11 @@ func (cs *ChainService) getStaking(addr []byte) (*types.Staking, error) {
 	}
 
 	sdb := cs.sdb.OpenNewStateDB(cs.sdb.GetRoot())
-	scs, err := state.GetSystemAccountState(sdb)
+	scs, err := statedb.GetSystemAccountState(sdb)
 	if err != nil {
 		return nil, err
 	}
-	namescs, err := state.GetNameAccountState(sdb)
+	namescs, err := statedb.GetNameAccountState(sdb)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func (cs *ChainService) getNameInfo(qname string, blockNo types.BlockNo) (*types
 		stateDB = cs.sdb.OpenNewStateDB(cs.sdb.GetRoot())
 	}
 
-	ncs, err := state.GetNameAccountState(stateDB)
+	ncs, err := statedb.GetNameAccountState(stateDB)
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +576,7 @@ func (cs *ChainService) getNameInfo(qname string, blockNo types.BlockNo) (*types
 
 func (cs *ChainService) getEnterpriseConf(key string) (*types.EnterpriseConfig, error) {
 	sdb := cs.sdb.OpenNewStateDB(cs.sdb.GetRoot())
-	ecs, err := state.GetEnterpriseAccountState(sdb)
+	ecs, err := statedb.GetEnterpriseAccountState(sdb)
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +589,7 @@ func (cs *ChainService) getEnterpriseConf(key string) (*types.EnterpriseConfig, 
 func (cs *ChainService) getSystemValue(key types.SystemValue) (*big.Int, error) {
 	switch key {
 	case types.StakingTotal:
-		scs, err := state.GetSystemAccountState(cs.sdb.GetStateDB())
+		scs, err := statedb.GetSystemAccountState(cs.sdb.GetStateDB())
 		if err != nil {
 			return nil, err
 		}
@@ -701,7 +701,7 @@ func (cm *ChainManager) Receive(context actor.Context) {
 
 func getAddressNameResolved(sdb *statedb.StateDB, account []byte) ([]byte, error) {
 	if len(account) == types.NameLength {
-		scs, err := state.GetNameAccountState(sdb)
+		scs, err := statedb.GetNameAccountState(sdb)
 		if err != nil {
 			logger.Error().Str("hash", base58.Encode(account)).Err(err).Msg("failed to get state for account")
 			return nil, err
@@ -800,7 +800,7 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 			})
 			break
 		}
-		contractState, err := state.OpenContractStateAccount(address, sdb)
+		contractState, err := statedb.OpenContractStateAccount(address, sdb)
 		if err == nil {
 			abi, err := contract.GetABI(contractState, nil)
 			context.Respond(message.GetABIRsp{
@@ -822,7 +822,7 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 			context.Respond(message.GetQueryRsp{Result: nil, Err: err})
 			break
 		}
-		ctrState, err := state.OpenContractStateAccount(address, sdb)
+		ctrState, err := statedb.OpenContractStateAccount(address, sdb)
 		if err != nil {
 			logger.Error().Str("hash", base58.Encode(address)).Err(err).Msg("failed to get state for contract")
 			context.Respond(message.GetQueryRsp{Result: nil, Err: err})
@@ -910,7 +910,7 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 		defer runtime.UnlockOSThread()
 
 		sdb = cw.sdb.OpenNewStateDB(cw.sdb.GetRoot())
-		ctrState, err := state.OpenContractStateAccount(msg.Contract, sdb)
+		ctrState, err := statedb.OpenContractStateAccount(msg.Contract, sdb)
 		if err != nil {
 			logger.Error().Str("hash", base58.Encode(msg.Contract)).Err(err).Msg("failed to get state for contract")
 			context.Respond(message.CheckFeeDelegationRsp{Err: err})

--- a/chain/governance.go
+++ b/chain/governance.go
@@ -27,7 +27,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 
 	governance := string(txBody.Recipient)
 
-	scs, err := state.OpenContractState(receiver.AccountID(), receiver.State(), bs.StateDB)
+	scs, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/governance.go
+++ b/chain/governance.go
@@ -26,7 +26,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 	}
 
 	governance := string(txBody.Recipient)
-	scs, err := state.OpenContractState(receiver.IDNoPadding(), receiver.State(), bs.StateDB)
+	scs, err := statedb.OpenContractState(receiver.IDNoPadding(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 		err = types.ErrTxInvalidRecipient
 	}
 	if err == nil {
-		err = state.StageContractState(scs, bs.StateDB)
+		err = statedb.StageContractState(scs, bs.StateDB)
 	}
 
 	return events, err
@@ -56,7 +56,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 // InitGenesisBPs opens system contract and put initial voting result
 // it also set *State in Genesis to use statedb
 func InitGenesisBPs(states *statedb.StateDB, genesis *types.Genesis) error {
-	scs, err := state.GetSystemAccountState(states)
+	scs, err := statedb.GetSystemAccountState(states)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func InitGenesisBPs(states *statedb.StateDB, genesis *types.Genesis) error {
 	// Set genesis.BPs to the votes-ordered BPs. This will be used later for
 	// bootstrapping.
 	genesis.BPs = system.BuildOrderedCandidates(voteResult)
-	if err = state.StageContractState(scs, states); err != nil {
+	if err = statedb.StageContractState(scs, states); err != nil {
 		return err
 	}
 	if err = states.Update(); err != nil {

--- a/chain/governance.go
+++ b/chain/governance.go
@@ -26,8 +26,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 	}
 
 	governance := string(txBody.Recipient)
-
-	scs, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
+	scs, err := state.OpenContractState(receiver.IDNoPadding(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/reorg.go
+++ b/chain/reorg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aergoio/aergo/v2/contract/system"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/message"
 )
@@ -168,7 +169,7 @@ func (cs *ChainService) reorg(topBlock *types.Block, marker *ReorgMarker) error 
 	}
 
 	cs.stat.updateEvent(ReorgStat, time.Since(begT), reorg.oldBlocks[0], reorg.newBlocks[0], reorg.brStartBlock)
-	systemStateDB, err := cs.SDB().GetSystemAccountState()
+	systemStateDB, err := statedb.GetSystemAccountState(cs.SDB().GetStateDB())
 	system.InitSystemParams(systemStateDB, system.RESET)
 	logger.Info().Msg("reorg end")
 

--- a/chain/signVerifier.go
+++ b/chain/signVerifier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/pkg/component"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/message"
 )
@@ -132,7 +133,7 @@ func (sv *SignVerifier) verifyTx(comm component.IComponentRequester, tx *types.T
 	}
 
 	if tx.NeedNameVerify() {
-		cs, err := state.GetNameAccountState(sv.sdb.GetStateDB())
+		cs, err := statedb.GetNameAccountState(sv.sdb.GetStateDB())
 		if err != nil {
 			logger.Error().Err(err).Msg("failed to get verify because of opening contract error")
 			return false, err

--- a/cmd/brick/exec/getstateAccount.go
+++ b/cmd/brick/exec/getstateAccount.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/aergoio/aergo/v2/cmd/brick/context"
 	"github.com/aergoio/aergo/v2/contract/vm_dummy"
@@ -66,9 +65,9 @@ func (c *getStateAccount) Run(args string) (string, uint64, []*types.Event, erro
 		return "", 0, nil, err
 	}
 	if expectedResult == "" {
-		return fmt.Sprintf("%s = %d", vm_dummy.StrToAddress(accountName), new(big.Int).SetBytes(state.GetBalance())), 0, nil, nil
+		return fmt.Sprintf("%s = %s", vm_dummy.StrToAddress(accountName), state.GetBalanceBigInt().String()), 0, nil, nil
 	} else {
-		strRet := fmt.Sprintf("%d", new(big.Int).SetBytes(state.GetBalance()))
+		strRet := state.GetBalanceBigInt().String()
 		if expectedResult == strRet {
 			return "state compare successfully", 0, nil, nil
 		} else {

--- a/consensus/impl/dpos/blockfactory_test.go
+++ b/consensus/impl/dpos/blockfactory_test.go
@@ -2,9 +2,10 @@ package dpos
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBlockFactory_context(t *testing.T) {

--- a/consensus/impl/dpos/bp/cluster.go
+++ b/consensus/impl/dpos/bp/cluster.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aergoio/aergo/v2/contract/system"
 	"github.com/aergoio/aergo/v2/internal/enc/gob"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/davecgh/go-spew/spew"
 )
@@ -381,7 +382,7 @@ func (sn *Snapshots) AddSnapshot(refBlockNo types.BlockNo) ([]string, error) {
 }
 
 func (sn *Snapshots) gatherRankers() ([]string, error) {
-	scs, err := state.GetSystemAccountState(sn.sdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(sn.sdb.GetStateDB())
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +501,7 @@ func (sn *Snapshots) loadClusterSnapshot(blockNo types.BlockNo) ([]string, error
 	}
 
 	stateDB := sn.sdb.OpenNewStateDB(block.GetHeader().GetBlocksRootHash())
-	scs, err := state.GetSystemAccountState(stateDB)
+	scs, err := statedb.GetSystemAccountState(stateDB)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/impl/dpos/dpos.go
+++ b/consensus/impl/dpos/dpos.go
@@ -207,7 +207,7 @@ func sendVotingReward(bState *state.BlockState, dummy []byte) error {
 }
 
 func InitVPR(sdb *statedb.StateDB) error {
-	s, err := state.GetSystemAccountState(sdb)
+	s, err := statedb.GetSystemAccountState(sdb)
 	if err != nil {
 		return err
 	}

--- a/consensus/impl/dpos/dpos.go
+++ b/consensus/impl/dpos/dpos.go
@@ -185,11 +185,15 @@ func sendVotingReward(bState *state.BlockState, dummy []byte) error {
 	}
 
 	// send reward ( vault -> winner )
-	winnerAccountState.AddBalance(reward)
+	err = state.SendBalance(vaultAccountState, winnerAccountState, reward)
+	if err != nil {
+		logger.Info().Err(err).Msg("send voting reward failed")
+		return nil
+	}
+
 	if err = winnerAccountState.PutState(); err != nil {
 		return err
 	}
-	vaultAccountState.SubBalance(reward)
 	if err = vaultAccountState.PutState(); err != nil {
 		return err
 	}

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aergoio/aergo/v2/fee"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 	"github.com/minio/sha256-simd"
@@ -106,7 +107,7 @@ func Execute(execCtx context.Context, bs *state.BlockState, cdb ChainAccessor, t
 	}
 
 	// open the contract state
-	contractState, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
+	contractState, err := statedb.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return
 	}
@@ -194,7 +195,7 @@ func Execute(execCtx context.Context, bs *state.BlockState, cdb ChainAccessor, t
 	}
 
 	// save the contract state
-	err = state.StageContractState(contractState, bs.StateDB)
+	err = statedb.StageContractState(contractState, bs.StateDB)
 	if err != nil {
 		return "", events, usedFee, err
 	}
@@ -268,7 +269,7 @@ func preloadWorker() {
 		}
 
 		// open the contract state
-		contractState, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
+		contractState, err := statedb.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 		if err != nil {
 			replyCh <- &preloadReply{tx, nil, err}
 			continue
@@ -320,7 +321,7 @@ func CreateContractID(account []byte, nonce uint64) []byte {
 	return append([]byte{0x0C}, recipientHash...) // prepend 0x0C to make it same length as account addresses
 }
 
-func checkRedeploy(sender, receiver *state.AccountState, contractState *state.ContractState) error {
+func checkRedeploy(sender, receiver *state.AccountState, contractState *statedb.ContractState) error {
 	// check if the contract exists
 	if !receiver.IsContract() || receiver.IsNew() {
 		receiverAddr := types.EncodeAddress(receiver.ID())

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -106,7 +106,7 @@ func Execute(execCtx context.Context, bs *state.BlockState, cdb ChainAccessor, t
 	}
 
 	// open the contract state
-	contractState, err := state.OpenContractState(receiver.AccountID(), receiver.State(), bs.StateDB)
+	contractState, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return
 	}
@@ -268,7 +268,7 @@ func preloadWorker() {
 		}
 
 		// open the contract state
-		contractState, err := state.OpenContractState(receiver.AccountID(), receiver.State(), bs.StateDB)
+		contractState, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 		if err != nil {
 			replyCh <- &preloadReply{tx, nil, err}
 			continue

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -81,16 +81,9 @@ func Execute(execCtx context.Context, bs *state.BlockState, cdb ChainAccessor, t
 	// compute the base fee
 	usedFee = fee.TxBaseFee(bi.ForkVersion, bs.GasPrice, len(txPayload))
 
-	// check if sender and receiver are not the same
-	if sender.AccountID() != receiver.AccountID() {
-		// check if sender has enough balance
-		if sender.Balance().Cmp(txBody.GetAmountBigInt()) < 0 {
-			err = types.ErrInsufficientBalance
-			return
-		}
-		// transfer the amount from the sender to the receiver
-		sender.SubBalance(txBody.GetAmountBigInt())
-		receiver.AddBalance(txBody.GetAmountBigInt())
+	// transfer the amount from the sender to the receiver
+	if err = state.SendBalance(sender, receiver, txBody.GetAmountBigInt()); err != nil {
+		return
 	}
 
 	// check if the tx is valid and if the code should be executed

--- a/contract/enterprise/admin.go
+++ b/contract/enterprise/admin.go
@@ -3,12 +3,12 @@ package enterprise
 import (
 	"bytes"
 
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
 
-func GetAdmin(ecs *state.ContractState) (*types.EnterpriseConfig, error) {
+func GetAdmin(ecs *statedb.ContractState) (*types.EnterpriseConfig, error) {
 	admins, err := getAdmins(ecs)
 	if err != nil {
 		return nil, err
@@ -22,11 +22,11 @@ func GetAdmin(ecs *state.ContractState) (*types.EnterpriseConfig, error) {
 	}
 	return ret, nil
 }
-func setAdmins(scs *state.ContractState, addresses [][]byte) error {
+func setAdmins(scs *statedb.ContractState, addresses [][]byte) error {
 	return scs.SetData(dbkey.EnterpriseAdmins(), bytes.Join(addresses, []byte("")))
 }
 
-func getAdmins(scs *state.ContractState) ([][]byte, error) {
+func getAdmins(scs *statedb.ContractState) ([][]byte, error) {
 	data, err := scs.GetData(dbkey.EnterpriseAdmins())
 	if err != nil {
 		return nil, err

--- a/contract/enterprise/config.go
+++ b/contract/enterprise/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
@@ -70,7 +70,7 @@ func (c *Conf) Validate(key []byte, context *EnterpriseContext) error {
 	}
 }
 
-func GetConf(ecs *state.ContractState, key string) (*types.EnterpriseConfig, error) {
+func GetConf(ecs *statedb.ContractState, key string) (*types.EnterpriseConfig, error) {
 	ret := &types.EnterpriseConfig{Key: key}
 	if strings.ToUpper(key) == "PERMISSIONS" {
 		for k := range enterpriseKeyDict {
@@ -89,7 +89,7 @@ func GetConf(ecs *state.ContractState, key string) (*types.EnterpriseConfig, err
 	return ret, nil
 }
 
-func enableConf(scs *state.ContractState, key []byte, value bool) (*Conf, error) {
+func enableConf(scs *statedb.ContractState, key []byte, value bool) (*Conf, error) {
 	conf, err := getConf(scs, key)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func enableConf(scs *state.ContractState, key []byte, value bool) (*Conf, error)
 	return conf, nil
 }
 
-func getConf(scs *state.ContractState, key []byte) (*Conf, error) {
+func getConf(scs *statedb.ContractState, key []byte) (*Conf, error) {
 	data, err := scs.GetData(dbkey.EnterpriseConf(key))
 	if err != nil || data == nil {
 		return nil, err
@@ -110,7 +110,7 @@ func getConf(scs *state.ContractState, key []byte) (*Conf, error) {
 	return deserializeConf(data), err
 }
 
-func setConfValues(scs *state.ContractState, key []byte, values []string) (*Conf, error) {
+func setConfValues(scs *statedb.ContractState, key []byte, values []string) (*Conf, error) {
 	conf, err := getConf(scs, key)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func setConfValues(scs *state.ContractState, key []byte, values []string) (*Conf
 	return conf, nil
 }
 
-func setConf(scs *state.ContractState, key []byte, conf *Conf) error {
+func setConf(scs *statedb.ContractState, key []byte, conf *Conf) error {
 	return scs.SetData(dbkey.EnterpriseConf(key), serializeConf(conf))
 }
 

--- a/contract/enterprise/config_test.go
+++ b/contract/enterprise/config_test.go
@@ -14,7 +14,7 @@ import (
 var cdb *state.ChainStateDB
 var sdb *statedb.StateDB
 
-func initTest(t *testing.T) (*state.ContractState, *state.AccountState, *state.AccountState) {
+func initTest(t *testing.T) (*statedb.ContractState, *state.AccountState, *state.AccountState) {
 	cdb = state.NewChainStateDB()
 	cdb.Init(string(db.BadgerImpl), "test", nil, false)
 	genesis := types.GetTestGenesis()
@@ -25,7 +25,7 @@ func initTest(t *testing.T) (*state.ContractState, *state.AccountState, *state.A
 	}
 	const testSender = "AmPNYHyzyh9zweLwDyuoiUuTVCdrdksxkRWDjVJS76WQLExa2Jr4"
 
-	scs, err := state.GetSystemAccountState(cdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 
 	account, err := types.DecodeAddress(testSender)

--- a/contract/enterprise/execute.go
+++ b/contract/enterprise/execute.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aergoio/aergo-lib/log"
 	"github.com/aergoio/aergo/v2/consensus"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
@@ -52,7 +53,7 @@ func (e *EnterpriseContext) HasConfValue(value string) bool {
 	return false
 }
 
-func ExecuteEnterpriseTx(bs *state.BlockState, ccc consensus.ChainConsensusCluster, scs *state.ContractState, txBody *types.TxBody,
+func ExecuteEnterpriseTx(bs *state.BlockState, ccc consensus.ChainConsensusCluster, scs *statedb.ContractState, txBody *types.TxBody,
 	sender, receiver *state.AccountState, blockNo types.BlockNo) ([]*types.Event, error) {
 
 	context, err := ValidateEnterpriseTx(txBody, sender, scs, blockNo)

--- a/contract/enterprise/validate.go
+++ b/contract/enterprise/validate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aergoio/aergo/v2/consensus"
 	"github.com/aergoio/aergo/v2/internal/enc/base64"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
@@ -25,7 +26,7 @@ const ChangeCluster = "changeCluster"
 var ErrTxEnterpriseAdminIsNotSet = errors.New("admin is not set")
 
 func ValidateEnterpriseTx(tx *types.TxBody, sender *state.AccountState,
-	scs *state.ContractState, blockNo types.BlockNo) (*EnterpriseContext, error) {
+	scs *statedb.ContractState, blockNo types.BlockNo) (*EnterpriseContext, error) {
 	var ci types.CallInfo
 	if err := json.Unmarshal(tx.Payload, &ci); err != nil {
 		return nil, err
@@ -185,7 +186,7 @@ func ValidateEnterpriseTx(tx *types.TxBody, sender *state.AccountState,
 	return context, nil
 }
 
-func checkAdmin(scs *state.ContractState, address []byte) ([][]byte, error) {
+func checkAdmin(scs *statedb.ContractState, address []byte) ([][]byte, error) {
 	admins, err := getAdmins(scs)
 	if err != nil {
 		return nil, fmt.Errorf("could not get admin in enterprise contract")

--- a/contract/name/execute.go
+++ b/contract/name/execute.go
@@ -136,8 +136,9 @@ func SetContractOwner(bs *state.BlockState, scs *statedb.ContractState,
 		return nil, err
 	}
 
-	ownerState.AddBalance(nameState.Balance())
-	nameState.SubBalance(nameState.Balance())
+	if err = state.SendBalance(nameState, ownerState, nameState.Balance()); err != nil {
+		return nil, err
+	}
 
 	name := []byte(types.AergoName)
 	if err = registerOwner(scs, name, rawaddr, name); err != nil {

--- a/contract/name/execute.go
+++ b/contract/name/execute.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/aergoio/aergo/v2/contract/system"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
-func ExecuteNameTx(bs *state.BlockState, scs *state.ContractState, txBody *types.TxBody,
+func ExecuteNameTx(bs *state.BlockState, scs *statedb.ContractState, txBody *types.TxBody,
 	sender, receiver *state.AccountState, blockInfo *types.BlockHeaderInfo) ([]*types.Event, error) {
 
 	ci, err := ValidateNameTx(txBody, sender, scs)
@@ -84,7 +85,7 @@ func ExecuteNameTx(bs *state.BlockState, scs *state.ContractState, txBody *types
 	return events, nil
 }
 
-func ValidateNameTx(tx *types.TxBody, sender *state.AccountState, scs *state.ContractState) (*types.CallInfo, error) {
+func ValidateNameTx(tx *types.TxBody, sender *state.AccountState, scs *statedb.ContractState) (*types.CallInfo, error) {
 	if sender != nil && sender.Balance().Cmp(tx.GetAmountBigInt()) < 0 {
 		return nil, types.ErrInsufficientBalance
 	}
@@ -122,7 +123,7 @@ func ValidateNameTx(tx *types.TxBody, sender *state.AccountState, scs *state.Con
 	return &ci, nil
 }
 
-func SetContractOwner(bs *state.BlockState, scs *state.ContractState,
+func SetContractOwner(bs *state.BlockState, scs *statedb.ContractState,
 	address string, nameState *state.AccountState) (*state.AccountState, error) {
 
 	rawaddr, err := types.DecodeAddress(address)

--- a/contract/name/execute_test.go
+++ b/contract/name/execute_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -112,26 +113,26 @@ func TestExcuteFailNameTx(t *testing.T) {
 	assert.Error(t, err, "execute name tx")
 }
 
-func openContractState(t *testing.T, bs *state.BlockState) *state.ContractState {
-	scs, err := state.GetNameAccountState(bs.StateDB)
+func openContractState(t *testing.T, bs *state.BlockState) *statedb.ContractState {
+	scs, err := statedb.GetNameAccountState(bs.StateDB)
 	assert.NoError(t, err, "could not open contract state")
 	return scs
 }
 
-func openSystemContractState(t *testing.T, bs *state.BlockState) *state.ContractState {
-	scs, err := state.GetSystemAccountState(bs.StateDB)
+func openSystemContractState(t *testing.T, bs *state.BlockState) *statedb.ContractState {
+	scs, err := statedb.GetSystemAccountState(bs.StateDB)
 	assert.NoError(t, err, "could not open contract state")
 	return scs
 }
 
-func commitContractState(t *testing.T, bs *state.BlockState, scs *state.ContractState) {
-	state.StageContractState(scs, bs.StateDB)
+func commitContractState(t *testing.T, bs *state.BlockState, scs *statedb.ContractState) {
+	statedb.StageContractState(scs, bs.StateDB)
 	bs.Update()
 	bs.Commit()
 	sdb.UpdateRoot(bs)
 }
 
-func nextBlockContractState(t *testing.T, bs *state.BlockState, scs *state.ContractState) *state.ContractState {
+func nextBlockContractState(t *testing.T, bs *state.BlockState, scs *statedb.ContractState) *statedb.ContractState {
 	commitContractState(t, bs, scs)
 	return openContractState(t, bs)
 }

--- a/contract/name/name.go
+++ b/contract/name/name.go
@@ -40,7 +40,7 @@ func UpdateName(bs *state.BlockState, scs *state.ContractState, tx *types.TxBody
 	amount := tx.GetAmountBigInt()
 	sender.SubBalance(amount)
 	receiver.AddBalance(amount)
-	contract, err := state.OpenContractStateAccount(types.ToAccountID(destination), bs.StateDB)
+	contract, err := state.OpenContractStateAccount(destination, bs.StateDB)
 	if err != nil {
 		return types.ErrTxInvalidRecipient
 	}
@@ -87,7 +87,7 @@ func openContract(bs *state.BlockState) (*state.ContractState, error) {
 	if err != nil {
 		return nil, err
 	}
-	scs, err := state.OpenContractState(v.AccountID(), v.State(), bs.StateDB)
+	scs, err := state.OpenContractState(v.ID(), v.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}

--- a/contract/name/name.go
+++ b/contract/name/name.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
@@ -16,20 +17,20 @@ type NameMap struct {
 	Destination []byte
 }
 
-func CreateName(scs *state.ContractState, tx *types.TxBody, sender, receiver *state.AccountState, name string) error {
+func CreateName(scs *statedb.ContractState, tx *types.TxBody, sender, receiver *state.AccountState, name string) error {
 	amount := tx.GetAmountBigInt()
 	sender.SubBalance(amount)
 	receiver.AddBalance(amount)
 	return createName(scs, []byte(name), sender.ID())
 }
 
-func createName(scs *state.ContractState, name []byte, owner []byte) error {
+func createName(scs *statedb.ContractState, name []byte, owner []byte) error {
 	//	return setAddress(scs, name, owner)
 	return registerOwner(scs, name, owner, owner)
 }
 
 // UpdateName is avaliable after bid implement
-func UpdateName(bs *state.BlockState, scs *state.ContractState, tx *types.TxBody,
+func UpdateName(bs *state.BlockState, scs *statedb.ContractState, tx *types.TxBody,
 	sender, receiver *state.AccountState, name, to string) error {
 	if len(getAddress(scs, []byte(name))) <= types.NameLength {
 		return fmt.Errorf("%s is not created yet", string(name))
@@ -40,7 +41,7 @@ func UpdateName(bs *state.BlockState, scs *state.ContractState, tx *types.TxBody
 	amount := tx.GetAmountBigInt()
 	sender.SubBalance(amount)
 	receiver.AddBalance(amount)
-	contract, err := state.OpenContractStateAccount(destination, bs.StateDB)
+	contract, err := statedb.OpenContractStateAccount(destination, bs.StateDB)
 	if err != nil {
 		return types.ErrTxInvalidRecipient
 	}
@@ -58,7 +59,7 @@ func UpdateName(bs *state.BlockState, scs *state.ContractState, tx *types.TxBody
 	return updateName(scs, []byte(name), ownerAddr, destination)
 }
 
-func updateName(scs *state.ContractState, name []byte, owner []byte, to []byte) error {
+func updateName(scs *statedb.ContractState, name []byte, owner []byte, to []byte) error {
 	//return setAddress(scs, name, to)
 	return registerOwner(scs, name, owner, to)
 }
@@ -82,12 +83,12 @@ func Resolve(bs *state.BlockState, name []byte, legacy bool) ([]byte, error) {
 	return getAddress(scs, name), nil
 }
 
-func openContract(bs *state.BlockState) (*state.ContractState, error) {
+func openContract(bs *state.BlockState) (*statedb.ContractState, error) {
 	v, err := state.GetAccountState([]byte(types.AergoName), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}
-	scs, err := state.OpenContractState(v.ID(), v.State(), bs.StateDB)
+	scs, err := statedb.OpenContractState(v.ID(), v.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func openContract(bs *state.BlockState) (*state.ContractState, error) {
 }
 
 // GetAddress is resolve name for mempool
-func GetAddress(scs *state.ContractState, name []byte) []byte {
+func GetAddress(scs *statedb.ContractState, name []byte) []byte {
 	if len(name) == types.AddressLength || types.IsSpecialAccount(name) {
 		return name
 	}
@@ -103,14 +104,14 @@ func GetAddress(scs *state.ContractState, name []byte) []byte {
 }
 
 // GetAddressLegacy is resolve name for mempool by buggy logic, leaved for backward compatibility
-func GetAddressLegacy(scs *state.ContractState, name []byte) []byte {
+func GetAddressLegacy(scs *statedb.ContractState, name []byte) []byte {
 	if len(name) == types.AddressLength || strings.Contains(string(name), ".") {
 		return name
 	}
 	return getAddress(scs, name)
 }
 
-func getAddress(scs *state.ContractState, name []byte) []byte {
+func getAddress(scs *statedb.ContractState, name []byte) []byte {
 	nameMap := getNameMap(scs, name, true)
 	if nameMap != nil {
 		return nameMap.Destination
@@ -118,11 +119,11 @@ func getAddress(scs *state.ContractState, name []byte) []byte {
 	return nil
 }
 
-func GetOwner(scs *state.ContractState, name []byte) []byte {
+func GetOwner(scs *statedb.ContractState, name []byte) []byte {
 	return getOwner(scs, name, true)
 }
 
-func getOwner(scs *state.ContractState, name []byte, useInitial bool) []byte {
+func getOwner(scs *statedb.ContractState, name []byte, useInitial bool) []byte {
 	nameMap := getNameMap(scs, name, useInitial)
 	if nameMap != nil {
 		return nameMap.Owner
@@ -130,7 +131,7 @@ func getOwner(scs *state.ContractState, name []byte, useInitial bool) []byte {
 	return nil
 }
 
-func getNameMap(scs *state.ContractState, name []byte, useInitial bool) *NameMap {
+func getNameMap(scs *statedb.ContractState, name []byte, useInitial bool) *NameMap {
 	var err error
 	var ownerdata []byte
 	if useInitial {
@@ -144,17 +145,17 @@ func getNameMap(scs *state.ContractState, name []byte, useInitial bool) *NameMap
 	return deserializeNameMap(ownerdata)
 }
 
-func GetNameInfo(ncs *state.ContractState, name string) (*types.NameInfo, error) {
+func GetNameInfo(ncs *statedb.ContractState, name string) (*types.NameInfo, error) {
 	owner := getOwner(ncs, []byte(name), true)
 	return &types.NameInfo{Name: &types.Name{Name: string(name)}, Owner: owner, Destination: GetAddress(ncs, []byte(name))}, nil
 }
 
-func registerOwner(scs *state.ContractState, name, owner, destination []byte) error {
+func registerOwner(scs *statedb.ContractState, name, owner, destination []byte) error {
 	nameMap := &NameMap{Version: 1, Owner: owner, Destination: destination}
 	return setNameMap(scs, name, nameMap)
 }
 
-func setNameMap(scs *state.ContractState, name []byte, n *NameMap) error {
+func setNameMap(scs *statedb.ContractState, name []byte, n *NameMap) error {
 	return scs.SetData(dbkey.Name(name), serializeNameMap(n))
 }
 

--- a/contract/name/name.go
+++ b/contract/name/name.go
@@ -19,8 +19,9 @@ type NameMap struct {
 
 func CreateName(scs *statedb.ContractState, tx *types.TxBody, sender, receiver *state.AccountState, name string) error {
 	amount := tx.GetAmountBigInt()
-	sender.SubBalance(amount)
-	receiver.AddBalance(amount)
+	if err := state.SendBalance(sender, receiver, amount); err != nil {
+		return err
+	}
 	return createName(scs, []byte(name), sender.ID())
 }
 
@@ -39,8 +40,9 @@ func UpdateName(bs *state.BlockState, scs *statedb.ContractState, tx *types.TxBo
 	destination = GetAddress(scs, destination)
 
 	amount := tx.GetAmountBigInt()
-	sender.SubBalance(amount)
-	receiver.AddBalance(amount)
+	if err := state.SendBalance(sender, receiver, amount); err != nil {
+		return err
+	}
 	contract, err := statedb.OpenContractStateAccount(destination, bs.StateDB)
 	if err != nil {
 		return types.ErrTxInvalidRecipient

--- a/contract/name/name_test.go
+++ b/contract/name/name_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -116,7 +117,7 @@ func TestNameNil(t *testing.T) {
 	name1 := "AB1234567890"
 	name2 := "1234567890CD"
 
-	scs, err := state.GetSystemAccountState(sdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(sdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 	tx := &types.TxBody{Account: []byte(name1), Payload: buildNamePayload(name2, types.NameCreate, "")}
 	sender, _ := state.GetAccountState(tx.Account, sdb.GetStateDB())

--- a/contract/system/execute.go
+++ b/contract/system/execute.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
@@ -27,12 +28,12 @@ type SystemContext struct {
 	Receiver  *state.AccountState
 
 	op     types.OpSysTx
-	scs    *state.ContractState
+	scs    *statedb.ContractState
 	txBody *types.TxBody
 }
 
 func newSystemContext(account []byte, txBody *types.TxBody, sender, receiver *state.AccountState,
-	scs *state.ContractState, blockInfo *types.BlockHeaderInfo) (*SystemContext, error) {
+	scs *statedb.ContractState, blockInfo *types.BlockHeaderInfo) (*SystemContext, error) {
 	context, err := ValidateSystemTx(sender.ID(), txBody, sender, scs, blockInfo)
 	if err != nil {
 		return nil, err
@@ -59,7 +60,7 @@ type sysCmd interface {
 type sysCmdCtor func(ctx *SystemContext) (sysCmd, error)
 
 func newSysCmd(account []byte, txBody *types.TxBody, sender, receiver *state.AccountState,
-	scs *state.ContractState, blockInfo *types.BlockHeaderInfo) (sysCmd, error) {
+	scs *statedb.ContractState, blockInfo *types.BlockHeaderInfo) (sysCmd, error) {
 
 	cmds := map[types.OpSysTx]sysCmdCtor{
 		types.OpvoteBP:  newVoteCmd,
@@ -81,7 +82,7 @@ func newSysCmd(account []byte, txBody *types.TxBody, sender, receiver *state.Acc
 	return ctor(context)
 }
 
-func ExecuteSystemTx(scs *state.ContractState, txBody *types.TxBody,
+func ExecuteSystemTx(scs *statedb.ContractState, txBody *types.TxBody,
 	sender, receiver *state.AccountState, blockInfo *types.BlockHeaderInfo) ([]*types.Event, error) {
 
 	cmd, err := newSysCmd(sender.ID(), txBody, sender, receiver, scs, blockInfo)
@@ -97,7 +98,7 @@ func ExecuteSystemTx(scs *state.ContractState, txBody *types.TxBody,
 	return []*types.Event{event}, nil
 }
 
-func GetVotes(scs *state.ContractState, address []byte) ([]*types.VoteInfo, error) {
+func GetVotes(scs *statedb.ContractState, address []byte) ([]*types.VoteInfo, error) {
 	var results []*types.VoteInfo
 
 	for _, i := range GetVotingCatalog() {

--- a/contract/system/execute_test.go
+++ b/contract/system/execute_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/aergoio/aergo/v2/config"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -243,7 +243,7 @@ func TestValidateSystemTxForStaking(t *testing.T) {
 	scs, sender, receiver := initTest(t)
 	defer deinitTest()
 
-	scs, err := state.GetSystemAccountState(cdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 
 	tx := &types.Tx{
@@ -266,7 +266,7 @@ func TestValidateSystemTxForUnstaking(t *testing.T) {
 	defer deinitTest()
 	const testSender = "AmPNYHyzyh9zweLwDyuoiUuTVCdrdksxkRWDjVJS76WQLExa2Jr4"
 
-	scs, err := state.GetSystemAccountState(cdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 
 	account, err := types.DecodeAddress(testSender)

--- a/contract/system/param.go
+++ b/contract/system/param.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
@@ -190,19 +190,19 @@ func GetBpCount() int {
 
 // these functions are reading the param value directly from the state
 
-func GetNamePriceFromState(scs *state.ContractState) *big.Int {
+func GetNamePriceFromState(scs *statedb.ContractState) *big.Int {
 	return getParamFromState(scs, namePrice)
 }
 
-func GetStakingMinimumFromState(scs *state.ContractState) *big.Int {
+func GetStakingMinimumFromState(scs *statedb.ContractState) *big.Int {
 	return getParamFromState(scs, stakingMin)
 }
 
-func GetGasPriceFromState(scs *state.ContractState) *big.Int {
+func GetGasPriceFromState(scs *statedb.ContractState) *big.Int {
 	return getParamFromState(scs, gasPrice)
 }
 
-func getParamFromState(scs *state.ContractState, id sysParamIndex) *big.Int {
+func getParamFromState(scs *statedb.ContractState, id sysParamIndex) *big.Int {
 	data, err := scs.GetInitialData(dbkey.SystemParam(id.ID()))
 	if err != nil {
 		panic("could not get blockchain parameter")

--- a/contract/system/proposal_test.go
+++ b/contract/system/proposal_test.go
@@ -6,16 +6,16 @@ import (
 	"testing"
 
 	"github.com/aergoio/aergo/v2/config"
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 
 type TestAccountStateReader struct {
-	Scs *state.ContractState
+	Scs *statedb.ContractState
 }
 
-func (tas *TestAccountStateReader) GetSystemAccountState() (*state.ContractState, error) {
+func (tas *TestAccountStateReader) GetSystemAccountState() (*statedb.ContractState, error) {
 	if tas != nil && tas.Scs != nil {
 		return tas.Scs, nil
 	}

--- a/contract/system/staking.go
+++ b/contract/system/staking.go
@@ -100,7 +100,9 @@ func (c *unstakeCmd) run() (*types.Event, error) {
 	if err := subTotal(scs, balanceAdjustment); err != nil {
 		return nil, err
 	}
-	if err := state.SendBalance(sender, receiver, balanceAdjustment); err != nil {
+
+	// receive balance
+	if err := state.SendBalance(receiver, sender, balanceAdjustment); err != nil {
 		return nil, err
 	}
 

--- a/contract/system/staking.go
+++ b/contract/system/staking.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
@@ -116,11 +116,11 @@ func (c *unstakeCmd) run() (*types.Event, error) {
 	}, nil
 }
 
-func setStaking(scs *state.ContractState, account []byte, staking *types.Staking) error {
+func setStaking(scs *statedb.ContractState, account []byte, staking *types.Staking) error {
 	return scs.SetData(dbkey.SystemStaking(account), serializeStaking(staking))
 }
 
-func getStaking(scs *state.ContractState, account []byte) (*types.Staking, error) {
+func getStaking(scs *statedb.ContractState, account []byte) (*types.Staking, error) {
 	data, err := scs.GetData(dbkey.SystemStaking(account))
 	if err != nil {
 		return nil, err
@@ -132,18 +132,18 @@ func getStaking(scs *state.ContractState, account []byte) (*types.Staking, error
 	return &staking, nil
 }
 
-func GetStaking(scs *state.ContractState, address []byte) (*types.Staking, error) {
+func GetStaking(scs *statedb.ContractState, address []byte) (*types.Staking, error) {
 	if address != nil {
 		return getStaking(scs, address)
 	}
 	return nil, errors.New("invalid argument: address should not be nil")
 }
 
-func GetStakingTotal(scs *state.ContractState) (*big.Int, error) {
+func GetStakingTotal(scs *statedb.ContractState) (*big.Int, error) {
 	return getStakingTotal(scs)
 }
 
-func getStakingTotal(scs *state.ContractState) (*big.Int, error) {
+func getStakingTotal(scs *statedb.ContractState) (*big.Int, error) {
 	data, err := scs.GetData(dbkey.SystemStakingTotal())
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func getStakingTotal(scs *state.ContractState) (*big.Int, error) {
 	return new(big.Int).SetBytes(data), nil
 }
 
-func addTotal(scs *state.ContractState, amount *big.Int) error {
+func addTotal(scs *statedb.ContractState, amount *big.Int) error {
 	data, err := scs.GetData(dbkey.SystemStakingTotal())
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func addTotal(scs *state.ContractState, amount *big.Int) error {
 	return scs.SetData(dbkey.SystemStakingTotal(), new(big.Int).Add(total, amount).Bytes())
 }
 
-func subTotal(scs *state.ContractState, amount *big.Int) error {
+func subTotal(scs *statedb.ContractState, amount *big.Int) error {
 	data, err := scs.GetData(dbkey.SystemStakingTotal())
 	if err != nil {
 		return err

--- a/contract/system/staking.go
+++ b/contract/system/staking.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/aergoio/aergo/v2/state"
 	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
@@ -51,9 +52,9 @@ func (c *stakeCmd) run() (*types.Event, error) {
 	if err := addTotal(c.scs, amount); err != nil {
 		return nil, err
 	}
-	sender.SubBalance(amount)
-	receiver.AddBalance(amount)
-
+	if err := state.SendBalance(sender, receiver, amount); err != nil {
+		return nil, err
+	}
 	jsonArgs := ""
 	if c.SystemContext.BlockInfo.ForkVersion < 2 {
 		jsonArgs = `{"who":"` + types.EncodeAddress(sender.ID()) + `", "amount":"` + amount.String() + `"}`
@@ -99,8 +100,9 @@ func (c *unstakeCmd) run() (*types.Event, error) {
 	if err := subTotal(scs, balanceAdjustment); err != nil {
 		return nil, err
 	}
-	sender.AddBalance(balanceAdjustment)
-	receiver.SubBalance(balanceAdjustment)
+	if err := state.SendBalance(sender, receiver, balanceAdjustment); err != nil {
+		return nil, err
+	}
 
 	jsonArgs := ""
 	if c.SystemContext.BlockInfo.ForkVersion < 2 {

--- a/contract/system/staking_test.go
+++ b/contract/system/staking_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -139,7 +140,7 @@ func TestUnstakingError(t *testing.T) {
 	initTest(t)
 	defer deinitTest()
 	const testSender = "AmPNYHyzyh9zweLwDyuoiUuTVCdrdksxkRWDjVJS76WQLExa2Jr4"
-	scs, err := state.GetSystemAccountState(cdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(cdb.GetStateDB())
 	assert.Equal(t, err, nil, "could not open contract state")
 
 	account, err := types.DecodeAddress(testSender)

--- a/contract/system/validation.go
+++ b/contract/system/validation.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
 var ErrTxSystemOperatorIsNotSet = errors.New("operator is not set")
 
 func ValidateSystemTx(account []byte, txBody *types.TxBody, sender *state.AccountState,
-	scs *state.ContractState, blockInfo *types.BlockHeaderInfo) (*SystemContext, error) {
+	scs *statedb.ContractState, blockInfo *types.BlockHeaderInfo) (*SystemContext, error) {
 	var ci types.CallInfo
 	if err := json.Unmarshal(txBody.Payload, &ci); err != nil {
 		return nil, types.ErrTxInvalidPayload
@@ -110,7 +111,7 @@ func ValidateSystemTx(account []byte, txBody *types.TxBody, sender *state.Accoun
 	return context, nil
 }
 
-func checkStakingBefore(account []byte, scs *state.ContractState) (*types.Staking, error) {
+func checkStakingBefore(account []byte, scs *statedb.ContractState) (*types.Staking, error) {
 	staked, err := getStaking(scs, account)
 	if err != nil {
 		return nil, err
@@ -121,7 +122,7 @@ func checkStakingBefore(account []byte, scs *state.ContractState) (*types.Stakin
 	return staked, nil
 }
 
-func validateForStaking(account []byte, txBody *types.TxBody, scs *state.ContractState, blockNo uint64) (*types.Staking, error) {
+func validateForStaking(account []byte, txBody *types.TxBody, scs *statedb.ContractState, blockNo uint64) (*types.Staking, error) {
 	staked, err := getStaking(scs, account)
 	if err != nil {
 		return nil, err
@@ -137,7 +138,7 @@ func validateForStaking(account []byte, txBody *types.TxBody, scs *state.Contrac
 	return staked, nil
 }
 
-func validateForVote(account []byte, txBody *types.TxBody, scs *state.ContractState, blockNo uint64, voteKey []byte) (*types.Staking, *types.Vote, error) {
+func validateForVote(account []byte, txBody *types.TxBody, scs *statedb.ContractState, blockNo uint64, voteKey []byte) (*types.Staking, *types.Vote, error) {
 	staked, err := checkStakingBefore(account, scs)
 	if err != nil {
 		return nil, nil, types.ErrMustStakeBeforeVote
@@ -152,7 +153,7 @@ func validateForVote(account []byte, txBody *types.TxBody, scs *state.ContractSt
 	return staked, oldvote, nil
 }
 
-func validateForUnstaking(account []byte, txBody *types.TxBody, scs *state.ContractState, blockNo uint64) (*types.Staking, error) {
+func validateForUnstaking(account []byte, txBody *types.TxBody, scs *statedb.ContractState, blockNo uint64) (*types.Staking, error) {
 	staked, err := checkStakingBefore(account, scs)
 	if err != nil {
 		return nil, types.ErrMustStakeBeforeUnstake

--- a/contract/system/vote.go
+++ b/contract/system/vote.go
@@ -92,7 +92,7 @@ func (c *vprCmd) subVprWithHandleException(v *types.Vote) {
 	aid := c.Sender.AccountID()
 
 	// Handle exception 1. multisig contract ( AmhNcvE7RR84xoRzYNyATnwZR2JXaC5ut7neu89R13aj1b4eUxKp )
-	if aid.String() == "A9zXKkooeGYAZC5ReCcgeg4ddsvMHAy2ivUafXhrnzpj" && (no == 19612737 || no == 19612950 || no == 19613089 || no == 19613217 || no == 19613311) {
+	if aid.String() == "A9zXKkooeGYAZC5ReCcgeg4ddsvMHAy2ivUafXhrnzpj" {
 		votingPowerRank.sub(statedb.EmptyAccountID, c.Sender.ID(), v.GetAmountBigInt())
 		return
 	}
@@ -115,7 +115,7 @@ func (c *vprCmd) addVprWithHandleException(v *types.Vote) {
 	aid := c.Sender.AccountID()
 
 	// Handle exception 1. multisig contract ( AmhNcvE7RR84xoRzYNyATnwZR2JXaC5ut7neu89R13aj1b4eUxKp )
-	if aid.String() == "A9zXKkooeGYAZC5ReCcgeg4ddsvMHAy2ivUafXhrnzpj" && (no == 19612737 || no == 19612950 || no == 19613089 || no == 19613217 || no == 19613311) {
+	if aid.String() == "A9zXKkooeGYAZC5ReCcgeg4ddsvMHAy2ivUafXhrnzpj" {
 		votingPowerRank.add(statedb.EmptyAccountID, c.Sender.ID(), v.GetAmountBigInt())
 		return
 	}

--- a/contract/system/vote.go
+++ b/contract/system/vote.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
@@ -285,11 +285,11 @@ func refreshAllVote(context *SystemContext) error {
 }
 
 // GetVote return amount, to, err.
-func GetVote(scs *state.ContractState, voter []byte, issue []byte) (*types.Vote, error) {
+func GetVote(scs *statedb.ContractState, voter []byte, issue []byte) (*types.Vote, error) {
 	return getVote(scs, issue, voter)
 }
 
-func getVote(scs *state.ContractState, key, voter []byte) (*types.Vote, error) {
+func getVote(scs *statedb.ContractState, key, voter []byte) (*types.Vote, error) {
 	data, err := scs.GetData(dbkey.SystemVote(key, voter))
 	if err != nil {
 		return nil, err
@@ -306,7 +306,7 @@ func getVote(scs *state.ContractState, key, voter []byte) (*types.Vote, error) {
 	return &types.Vote{}, nil
 }
 
-func setVote(scs *state.ContractState, key, voter []byte, vote *types.Vote) error {
+func setVote(scs *statedb.ContractState, key, voter []byte, vote *types.Vote) error {
 	if bytes.Equal(key, defaultVoteKey) {
 		return scs.SetData(dbkey.SystemVote(key, voter), serializeVote(vote))
 	} else {
@@ -329,7 +329,7 @@ func BuildOrderedCandidates(vote map[string]*big.Int) []string {
 }
 
 // GetVoteResult returns the top n voting result from the system account state.
-func GetVoteResult(scs *state.ContractState, id []byte, n int) (*types.VoteList, error) {
+func GetVoteResult(scs *statedb.ContractState, id []byte, n int) (*types.VoteList, error) {
 	if !bytes.Equal(id, defaultVoteKey) {
 		id = GenProposalKey(string(id))
 	}
@@ -337,7 +337,7 @@ func GetVoteResult(scs *state.ContractState, id []byte, n int) (*types.VoteList,
 }
 
 // GetRankers returns the IDs of the top n rankers.
-func GetRankers(scs *state.ContractState) ([]string, error) {
+func GetRankers(scs *statedb.ContractState) ([]string, error) {
 	n := GetBpCount()
 
 	vl, err := GetVoteResult(scs, defaultVoteKey, n)

--- a/contract/system/vote.go
+++ b/contract/system/vote.go
@@ -75,11 +75,11 @@ func newVprCmd(ctx *SystemContext, vr *VoteResult) *vprCmd {
 		}
 	} else {
 		cmd.add = func(v *types.Vote) error {
-			cmd.addVpr(v) // calculate voting power rank with handle exception
+			cmd.addVpr(v) // calculate voting power rank with exception handling
 			return cmd.voteResult.AddVote(v)
 		}
 		cmd.sub = func(v *types.Vote) error {
-			cmd.subVpr(v) // calculate voting power rank with handle exception
+			cmd.subVpr(v) // calculate voting power rank with exception handling
 			return cmd.voteResult.SubVote(v)
 		}
 	}

--- a/contract/system/vote.go
+++ b/contract/system/vote.go
@@ -75,11 +75,11 @@ func newVprCmd(ctx *SystemContext, vr *VoteResult) *vprCmd {
 		}
 	} else {
 		cmd.add = func(v *types.Vote) error {
-			cmd.addVprWithHandleException(v) // calculate voting power rank with handle exception
+			cmd.addVpr(v) // calculate voting power rank with handle exception
 			return cmd.voteResult.AddVote(v)
 		}
 		cmd.sub = func(v *types.Vote) error {
-			cmd.subVprWithHandleException(v) // calculate voting power rank with handle exception
+			cmd.subVpr(v) // calculate voting power rank with handle exception
 			return cmd.voteResult.SubVote(v)
 		}
 	}
@@ -87,7 +87,7 @@ func newVprCmd(ctx *SystemContext, vr *VoteResult) *vprCmd {
 	return cmd
 }
 
-func (c *vprCmd) subVprWithHandleException(v *types.Vote) {
+func (c *vprCmd) subVpr(v *types.Vote) {
 	no := c.BlockInfo.No
 	aid := c.Sender.AccountID()
 
@@ -110,7 +110,7 @@ func (c *vprCmd) subVprWithHandleException(v *types.Vote) {
 	votingPowerRank.sub(aid, c.Sender.ID(), v.GetAmountBigInt())
 }
 
-func (c *vprCmd) addVprWithHandleException(v *types.Vote) {
+func (c *vprCmd) addVpr(v *types.Vote) {
 	no := c.BlockInfo.No
 	aid := c.Sender.AccountID()
 

--- a/contract/system/vote_test.go
+++ b/contract/system/vote_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ import (
 var cdb *state.ChainStateDB
 var bs *state.BlockState
 
-func initTest(t *testing.T) (*state.ContractState, *state.AccountState, *state.AccountState) {
+func initTest(t *testing.T) (*statedb.ContractState, *state.AccountState, *state.AccountState) {
 	cdb = state.NewChainStateDB()
 	cdb.Init(string(db.BadgerImpl), "test", nil, false)
 	genesis := types.GetTestGenesis()
@@ -37,7 +38,7 @@ func initTest(t *testing.T) (*state.ContractState, *state.AccountState, *state.A
 	// Need to pass the
 	const testSender = "AmPNYHyzyh9zweLwDyuoiUuTVCdrdksxkRWDjVJS76WQLExa2Jr4"
 
-	scs, err := state.GetSystemAccountState(bs.StateDB)
+	scs, err := statedb.GetSystemAccountState(bs.StateDB)
 	assert.NoError(t, err, "could not open contract state")
 	InitSystemParams(scs, 3)
 
@@ -58,12 +59,12 @@ func getSender(t *testing.T, addr string) *state.AccountState {
 	return sender
 }
 
-func commitNextBlock(t *testing.T, scs *state.ContractState) *state.ContractState {
-	state.StageContractState(scs, bs.StateDB)
+func commitNextBlock(t *testing.T, scs *statedb.ContractState) *statedb.ContractState {
+	statedb.StageContractState(scs, bs.StateDB)
 	bs.Update()
 	bs.Commit()
 	cdb.UpdateRoot(bs)
-	ret, err := state.GetSystemAccountState(bs.StateDB)
+	ret, err := statedb.GetSystemAccountState(bs.StateDB)
 	assert.NoError(t, err, "could not open contract state")
 	return ret
 }
@@ -77,7 +78,7 @@ func TestVoteResult(t *testing.T) {
 	const testSize = 64
 	initTest(t)
 	defer deinitTest()
-	scs, err := state.OpenContractStateAccount([]byte("testUpdateVoteResult"), cdb.GetStateDB())
+	scs, err := statedb.OpenContractStateAccount([]byte("testUpdateVoteResult"), cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 	testResult := map[string]*big.Int{}
 	for i := 0; i < testSize; i++ {
@@ -106,7 +107,7 @@ func TestVoteData(t *testing.T) {
 	const testSize = 64
 	initTest(t)
 	defer deinitTest()
-	scs, err := state.OpenContractStateAccount([]byte("testSetGetVoteDate"), cdb.GetStateDB())
+	scs, err := statedb.OpenContractStateAccount([]byte("testSetGetVoteDate"), cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 
 	for i := 0; i < testSize; i++ {

--- a/contract/system/vote_test.go
+++ b/contract/system/vote_test.go
@@ -77,7 +77,7 @@ func TestVoteResult(t *testing.T) {
 	const testSize = 64
 	initTest(t)
 	defer deinitTest()
-	scs, err := state.OpenContractStateAccount(types.ToAccountID([]byte("testUpdateVoteResult")), cdb.GetStateDB())
+	scs, err := state.OpenContractStateAccount([]byte("testUpdateVoteResult"), cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 	testResult := map[string]*big.Int{}
 	for i := 0; i < testSize; i++ {
@@ -106,7 +106,7 @@ func TestVoteData(t *testing.T) {
 	const testSize = 64
 	initTest(t)
 	defer deinitTest()
-	scs, err := state.OpenContractStateAccount(types.ToAccountID([]byte("testSetGetVoteDate")), cdb.GetStateDB())
+	scs, err := state.OpenContractStateAccount([]byte("testSetGetVoteDate"), cdb.GetStateDB())
 	assert.NoError(t, err, "could not open contract state")
 
 	for i := 0; i < testSize; i++ {

--- a/contract/system/voteresult.go
+++ b/contract/system/voteresult.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 )
@@ -20,7 +20,7 @@ type VoteResult struct {
 	ex    bool
 	total *big.Int
 
-	scs *state.ContractState
+	scs *statedb.ContractState
 }
 
 func newVoteResult(key []byte, total *big.Int) *VoteResult {
@@ -142,7 +142,7 @@ func (vr *VoteResult) threshold(power *big.Int) bool {
 	return false
 }
 
-func loadVoteResult(scs *state.ContractState, key []byte) (*VoteResult, error) {
+func loadVoteResult(scs *statedb.ContractState, key []byte) (*VoteResult, error) {
 	data, err := scs.GetData(dbkey.SystemVoteSort(key))
 	if err != nil {
 		return nil, err
@@ -169,7 +169,7 @@ func loadVoteResult(scs *state.ContractState, key []byte) (*VoteResult, error) {
 	return voteResult, nil
 }
 
-func InitVoteResult(scs *state.ContractState, voteResult map[string]*big.Int) error {
+func InitVoteResult(scs *statedb.ContractState, voteResult map[string]*big.Int) error {
 	if voteResult == nil {
 		return errors.New("Invalid argument : voteReult should not nil")
 	}
@@ -180,7 +180,7 @@ func InitVoteResult(scs *state.ContractState, voteResult map[string]*big.Int) er
 	return res.Sync()
 }
 
-func getVoteResult(scs *state.ContractState, key []byte, n int) (*types.VoteList, error) {
+func getVoteResult(scs *statedb.ContractState, key []byte, n int) (*types.VoteList, error) {
 	data, err := scs.GetData(dbkey.SystemVoteSort(key))
 	if err != nil {
 		return nil, err

--- a/contract/system/vprt.go
+++ b/contract/system/vprt.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/aergoio/aergo-lib/log"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
-	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 	rb "github.com/emirpasic/gods/trees/redblacktree"
@@ -641,7 +641,7 @@ func (v *vpr) sub(id types.AccountID, addr []byte, power *big.Int) {
 	)
 }
 
-func (v *vpr) apply(s *state.ContractState) (int, error) {
+func (v *vpr) apply(s *statedb.ContractState) (int, error) {
 	if v == nil || len(v.changes) == 0 {
 		return 0, nil
 	}

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -133,13 +133,13 @@ func InitContext(numCtx int) {
 	contexts = make([]*vmContext, maxContext)
 }
 
-func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, reciever *state.AccountState, contractState *statedb.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed, query bool, rp uint64, service int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
+func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, receiver *state.AccountState, contractState *statedb.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed, query bool, rp uint64, service int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
 
-	csReceiver := &callState{ctrState: contractState, accState: reciever}
+	csReceiver := &callState{ctrState: contractState, accState: receiver}
 	csSender := &callState{accState: sender}
 
 	ctx := &vmContext{
-		curContract:     newContractInfo(csReceiver, senderID, reciever.ID(), rp, amount),
+		curContract:     newContractInfo(csReceiver, senderID, receiver.ID(), rp, amount),
 		bs:              blockState,
 		cdb:             cdb,
 		origin:          senderID,
@@ -157,7 +157,7 @@ func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb Cha
 
 	// init call state
 	ctx.callState = make(map[types.AccountID]*callState)
-	ctx.callState[reciever.AccountID()] = csReceiver
+	ctx.callState[receiver.AccountID()] = csReceiver
 	if sender != nil {
 		ctx.callState[sender.AccountID()] = csSender
 	}
@@ -722,6 +722,7 @@ func (ce *executor) refreshRemainingGas() {
 func (ce *executor) gas() uint64 {
 	return uint64(C.lua_gasget(ce.L))
 }
+
 func (ce *executor) vmLoadCode(id []byte) {
 	var chunkId *C.char
 	if ce.ctx.blockInfo.ForkVersion >= 3 {

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -133,25 +133,7 @@ func InitContext(numCtx int) {
 	contexts = make([]*vmContext, maxContext)
 }
 
-func newContractInfo(cs *callState, sender, contractId []byte, rp uint64, amount *big.Int) *contractInfo {
-	return &contractInfo{
-		cs,
-		sender,
-		contractId,
-		rp,
-		amount,
-	}
-}
-
-func getTraceFile(blkno uint64, tx []byte) *os.File {
-	f, _ := os.OpenFile(fmt.Sprintf("%s%s%d.trace", os.TempDir(), string(os.PathSeparator), blkno), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	if f != nil {
-		_, _ = f.WriteString(fmt.Sprintf("[START TX]: %s\n", base58.Encode(tx)))
-	}
-	return f
-}
-
-func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, reciever *state.AccountState, contractState *state.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed, query bool, rp uint64, executionMode int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
+func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, receiver *state.AccountState, contractState *statedb.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed, query bool, rp uint64, executionMode int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
 
 	csReceiver := &callState{ctrState: contractState, accState: receiver}
 	csSender := &callState{accState: sender}

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -133,7 +133,9 @@ func InitContext(numCtx int) {
 	contexts = make([]*vmContext, maxContext)
 }
 
-func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, receiver *state.AccountState, contractState *statedb.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed, query bool, rp uint64, executionMode int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
+func NewVmContext(execCtx context.Context, blockState *state.BlockState, cdb ChainAccessor, sender, receiver *state.AccountState,
+	contractState *statedb.ContractState, senderID, txHash []byte, bi *types.BlockHeaderInfo, node string, confirmed,
+	query bool, rp uint64, executionMode int, amount *big.Int, gasLimit uint64, feeDelegation bool) *vmContext {
 
 	csReceiver := &callState{ctrState: contractState, accState: receiver}
 	csSender := &callState{accState: sender}
@@ -753,9 +755,7 @@ func (ce *executor) vmLoadCode(id []byte) {
 }
 
 func (ce *executor) vmLoadCall() {
-	if cErrMsg := C.vm_loadcall(
-		ce.L,
-	); cErrMsg != nil {
+	if cErrMsg := C.vm_loadcall(ce.L); cErrMsg != nil {
 		errMsg := C.GoString(cErrMsg)
 		ce.err = errors.New(errMsg)
 	}

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -270,7 +270,7 @@ func luaCallContract(L *LState, service C.int, contractId *C.char, fname *C.char
 		}
 	}
 
-	seq, err := setRecoveryPoint(aid, ctx, senderState.State(), cs, amountBig, false, false)
+	seq, err := setRecoveryPoint(aid, ctx, senderState, cs, amountBig, false, false)
 	if ctx.traceFile != nil {
 		_, _ = ctx.traceFile.WriteString(fmt.Sprintf("[CALL Contract %v(%v) %v]\n",
 			contractAddress, aid.String(), fnameStr))
@@ -508,7 +508,7 @@ func luaSendAmount(L *LState, service C.int, contractId *C.char, amount *C.char)
 		}
 
 		// create a recovery point
-		seq, err := setRecoveryPoint(aid, ctx, senderState.State(), cs, amountBig, false, false)
+		seq, err := setRecoveryPoint(aid, ctx, senderState, cs, amountBig, false, false)
 		if err != nil {
 			return C.CString("[System.LuaSendAmount] database error: " + err.Error())
 		}
@@ -574,7 +574,7 @@ func luaSendAmount(L *LState, service C.int, contractId *C.char, amount *C.char)
 
 	// update the recovery point
 	if ctx.lastRecoveryEntry != nil {
-		_, _ = setRecoveryPoint(aid, ctx, senderState.State(), cs, amountBig, true, false)
+		_, _ = setRecoveryPoint(aid, ctx, senderState, cs, amountBig, true, false)
 	}
 
 	// log some info
@@ -1115,7 +1115,7 @@ func luaDeployContract(
 	}
 
 	// create a recovery point
-	seq, err := setRecoveryPoint(newContract.AccountID(), ctx, senderState.State(), cs, amountBig, false, true)
+	seq, err := setRecoveryPoint(newContract.AccountID(), ctx, senderState, cs, amountBig, false, true)
 	if err != nil {
 		return -1, C.CString("[System.LuaDeployContract] DB err:" + err.Error())
 	}
@@ -1341,7 +1341,7 @@ func luaGovernance(L *LState, service C.int, gType C.char, arg *C.char) *C.char 
 		return C.CString("[Contract.LuaGovernance] error: " + err.Error())
 	}
 
-	seq, err := setRecoveryPoint(aid, ctx, senderState.State(), scsState, zeroBig, false, false)
+	seq, err := setRecoveryPoint(aid, ctx, senderState, scsState, zeroBig, false, false)
 	if err != nil {
 		return C.CString("[Contract.LuaGovernance] database error: " + err.Error())
 	}
@@ -1367,7 +1367,7 @@ func luaGovernance(L *LState, service C.int, gType C.char, arg *C.char) *C.char 
 
 	if ctx.lastRecoveryEntry != nil {
 		if gType == 'S' {
-			seq, _ = setRecoveryPoint(aid, ctx, senderState.State(), scsState, amountBig, true, false)
+			seq, _ = setRecoveryPoint(aid, ctx, senderState, scsState, amountBig, true, false)
 			if ctx.traceFile != nil {
 				_, _ = ctx.traceFile.WriteString(fmt.Sprintf("[GOVERNANCE]aid(%s)\n", aid.String()))
 				_, _ = ctx.traceFile.WriteString(fmt.Sprintf("snapshot set %d\n", seq))
@@ -1376,7 +1376,7 @@ func luaGovernance(L *LState, service C.int, gType C.char, arg *C.char) *C.char 
 					senderState.Balance().String(), receiverState.Balance().String()))
 			}
 		} else if gType == 'U' {
-			seq, _ = setRecoveryPoint(aid, ctx, receiverState.State(), ctx.curContract.callState, amountBig, true, false)
+			seq, _ = setRecoveryPoint(aid, ctx, receiverState, ctx.curContract.callState, amountBig, true, false)
 			if ctx.traceFile != nil {
 				_, _ = ctx.traceFile.WriteString(fmt.Sprintf("[GOVERNANCE]aid(%s)\n", aid.String()))
 				_, _ = ctx.traceFile.WriteString(fmt.Sprintf("snapshot set %d\n", seq))

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -1325,10 +1325,6 @@ func luaGovernance(L *LState, service C.int, gType C.char, arg *C.char) *C.char 
 	senderState := curContract.callState.accState
 	receiverState := scsState.accState
 
-	if senderState.AccountID().String() == "A9zXKkooeGYAZC5ReCcgeg4ddsvMHAy2ivUafXhrnzpj" {
-		senderState.ClearAid()
-	}
-
 	txBody := types.TxBody{
 		Amount:  amountBig.Bytes(),
 		Payload: payload,

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/internal/enc/hex"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	"github.com/aergoio/aergo/v2/types/dbkey"
 	"github.com/btcsuite/btcd/btcec"
@@ -469,7 +470,7 @@ func luaSendAmount(L *LState, service C.int, contractId *C.char, amount *C.char)
 
 		// get the contract state
 		if cs.ctrState == nil {
-			cs.ctrState, err = state.OpenContractState(cid, receiverState.State(), ctx.bs.StateDB)
+			cs.ctrState, err = statedb.OpenContractState(cid, receiverState.State(), ctx.bs.StateDB)
 			if err != nil {
 				return C.CString("[Contract.LuaSendAmount] getContractState error: " + err.Error())
 			}
@@ -1083,7 +1084,7 @@ func luaDeployContract(
 	if err != nil {
 		return -1, C.CString("[Contract.LuaDeployContract]:" + err.Error())
 	}
-	contractState, err := state.OpenContractState(newContract.ID(), newContract.State(), bs.StateDB)
+	contractState, err := statedb.OpenContractState(newContract.ID(), newContract.State(), bs.StateDB)
 	if err != nil {
 		return -1, C.CString("[Contract.LuaDeployContract]:" + err.Error())
 	}
@@ -1493,18 +1494,18 @@ func luaGetStaking(service C.int, addr *C.char) (*C.char, C.lua_Integer, *C.char
 
 	var (
 		ctx          *vmContext
-		scs, namescs *state.ContractState
+		scs, namescs *statedb.ContractState
 		err          error
 		staking      *types.Staking
 	)
 
 	ctx = contexts[service]
-	scs, err = state.GetSystemAccountState(ctx.bs.StateDB)
+	scs, err = statedb.GetSystemAccountState(ctx.bs.StateDB)
 	if err != nil {
 		return nil, 0, C.CString(err.Error())
 	}
 
-	namescs, err = state.GetNameAccountState(ctx.bs.StateDB)
+	namescs, err = statedb.GetNameAccountState(ctx.bs.StateDB)
 	if err != nil {
 		return nil, 0, C.CString(err.Error())
 	}

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -1089,7 +1089,7 @@ func luaDeployContract(
 		return -1, C.CString("[Contract.LuaDeployContract]:" + err.Error())
 	}
 
-	cs := &callState{ctrState: contractState, accState: newContract}
+	cs := &callState{isDeploy: true, ctrState: contractState, accState: newContract}
 	ctx.callState[newContract.AccountID()] = cs
 
 	// read the amount transferred to the contract

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -223,7 +223,7 @@ func luaCallContract(L *LState, service C.int, contractId *C.char, fname *C.char
 	}
 
 	// get the contract state
-	cs, err := getCtrState(ctx, cid)
+	cs, err := getContractState(ctx, cid)
 	if err != nil {
 		return -1, C.CString("[Contract.LuaCallContract] getAccount error: " + err.Error())
 	}
@@ -1109,10 +1109,9 @@ func luaDeployContract(
 	senderState := prevContractInfo.callState.accState
 	receiverState := cs.accState
 	if amountBig.Cmp(zeroBig) > 0 {
-		if err := state.SendBalance(senderState, receiverState, amountBig); err != nil {
-			return -1, C.CString("[Contract.sendBalance] insufficient balance: " + senderState.Balance().String() + " : " + amountBig.String())
+		if rv := sendBalance(senderState, receiverState, amountBig); rv != nil {
+			return -1, rv
 		}
-
 	}
 
 	// create a recovery point
@@ -1315,7 +1314,7 @@ func luaGovernance(L *LState, service C.int, gType C.char, arg *C.char) *C.char 
 
 	cid := []byte(types.AergoSystem)
 	aid := types.ToAccountID(cid)
-	scsState, err := getCtrState(ctx, cid)
+	scsState, err := getContractState(ctx, cid)
 	if err != nil {
 		return C.CString("[Contract.LuaGovernance] getAccount error: " + err.Error())
 	}

--- a/contract/vm_callback.go
+++ b/contract/vm_callback.go
@@ -1089,7 +1089,7 @@ func luaDeployContract(
 		return -1, C.CString("[Contract.LuaDeployContract]:" + err.Error())
 	}
 
-	cs := &callState{isDeploy: true, ctrState: contractState, accState: newContract}
+	cs := &callState{isCallback: true, isDeploy: true, ctrState: contractState, accState: newContract}
 	ctx.callState[newContract.AccountID()] = cs
 
 	// read the amount transferred to the contract

--- a/contract/vm_direct/vm_direct.go
+++ b/contract/vm_direct/vm_direct.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aergoio/aergo/v2/fee"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
@@ -140,7 +141,7 @@ func LoadDummyChainEx(chainType ChainType) (*DummyChain, error) {
 	types.InitGovernance("dpos", true)
 
 	// To pass dao parameters test
-	scs, err := state.GetSystemAccountState(bc.sdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(bc.sdb.GetStateDB())
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +254,7 @@ func newBlockExecutor(bc *DummyChain, txs []*types.Tx) (*blockExecutor, error) {
 
 	exec = NewTxExecutor(context.Background(), nil, bc, bi, contract.ChainService)
 
-	scs, err := state.GetSystemAccountState(blockState.StateDB)
+	scs, err := statedb.GetSystemAccountState(blockState.StateDB)
 	if err != nil {
 		return nil, err
 	}
@@ -508,8 +509,8 @@ func executeTx(
 		if err != nil {
 			return err
 		}
-		var contractState *state.ContractState
-		contractState, err = state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
+		var contractState *statedb.ContractState
+		contractState, err = statedb.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 		if err != nil {
 			return err
 		}
@@ -597,7 +598,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 
 	governance := string(txBody.Recipient)
 
-	scs, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
+	scs, err := statedb.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}
@@ -615,7 +616,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 	}
 
 	if err == nil {
-		err = state.StageContractState(scs, bs.StateDB)
+		err = statedb.StageContractState(scs, bs.StateDB)
 	}
 
 	return events, err

--- a/contract/vm_direct/vm_direct.go
+++ b/contract/vm_direct/vm_direct.go
@@ -509,7 +509,7 @@ func executeTx(
 			return err
 		}
 		var contractState *state.ContractState
-		contractState, err = state.OpenContractState(receiver.AccountID(), receiver.State(), bs.StateDB)
+		contractState, err = state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 		if err != nil {
 			return err
 		}
@@ -597,7 +597,7 @@ func executeGovernanceTx(ccc consensus.ChainConsensusCluster, bs *state.BlockSta
 
 	governance := string(txBody.Recipient)
 
-	scs, err := state.OpenContractState(receiver.AccountID(), receiver.State(), bs.StateDB)
+	scs, err := state.OpenContractState(receiver.ID(), receiver.State(), bs.StateDB)
 	if err != nil {
 		return nil, err
 	}

--- a/contract/vm_dummy/vm_dummy.go
+++ b/contract/vm_dummy/vm_dummy.go
@@ -484,8 +484,11 @@ func contractFrame(l luaTxContract, bs *state.BlockState, cdb contract.ChainAcce
 			return types.ErrNotAllowedFeeDelegation
 		}
 	}
-	creatorState.SubBalance(l.amount())
-	contractState.AddBalance(l.amount())
+	err = state.SendBalance(creatorState, contractState, l.amount())
+	if err != nil {
+		return err
+	}
+
 	rv, events, cFee, err := run(creatorState, contractState, contractId, eContractState)
 	if cFee != nil {
 		usedFee.Add(usedFee, cFee)

--- a/contract/vm_dummy/vm_dummy.go
+++ b/contract/vm_dummy/vm_dummy.go
@@ -201,7 +201,7 @@ func (bc *DummyChain) BeginReceiptTx() db.Transaction {
 }
 
 func (bc *DummyChain) GetABI(code string) (*types.ABI, error) {
-	cState, err := state.OpenContractStateAccount(types.ToAccountID(contract.StrHash(code)), bc.sdb.GetStateDB())
+	cState, err := state.OpenContractStateAccount(contract.StrHash(code), bc.sdb.GetStateDB())
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func contractFrame(l luaTxContract, bs *state.BlockState, cdb contract.ChainAcce
 		return err
 	}
 
-	eContractState, err := state.OpenContractState(contractId, contractState.State(), bs.StateDB)
+	eContractState, err := state.OpenContractState(l.recipient(), contractState.State(), bs.StateDB)
 	if err != nil {
 		return err
 	}
@@ -674,7 +674,7 @@ func (bc *DummyChain) DisConnectBlock() error {
 }
 
 func (bc *DummyChain) Query(contract_name, queryInfo, expectedErr string, expectedRvs ...string) error {
-	cState, err := state.OpenContractStateAccount(types.ToAccountID(contract.StrHash(contract_name)), bc.sdb.GetStateDB())
+	cState, err := state.OpenContractStateAccount(contract.StrHash(contract_name), bc.sdb.GetStateDB())
 	if err != nil {
 		return err
 	}
@@ -703,7 +703,7 @@ func (bc *DummyChain) Query(contract_name, queryInfo, expectedErr string, expect
 }
 
 func (bc *DummyChain) QueryOnly(contract_name, queryInfo string, expectedErr string) (bool, string, error) {
-	cState, err := state.OpenContractStateAccount(types.ToAccountID(contract.StrHash(contract_name)), bc.sdb.GetStateDB())
+	cState, err := state.OpenContractStateAccount(contract.StrHash(contract_name), bc.sdb.GetStateDB())
 	if err != nil {
 		return false, "", err
 	}

--- a/contract/vm_dummy/vm_dummy.go
+++ b/contract/vm_dummy/vm_dummy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aergoio/aergo/v2/fee"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 	sha256 "github.com/minio/sha256-simd"
 )
@@ -136,7 +137,7 @@ func LoadDummyChain(opts ...DummyChainOptions) (*DummyChain, error) {
 	types.InitGovernance("dpos", true)
 
 	// To pass dao parameters test
-	scs, err := state.GetSystemAccountState(bc.sdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(bc.sdb.GetStateDB())
 	system.InitSystemParams(scs, 3)
 
 	fee.EnableZeroFee()
@@ -201,7 +202,7 @@ func (bc *DummyChain) BeginReceiptTx() db.Transaction {
 }
 
 func (bc *DummyChain) GetABI(code string) (*types.ABI, error) {
-	cState, err := state.OpenContractStateAccount(contract.StrHash(code), bc.sdb.GetStateDB())
+	cState, err := statedb.OpenContractStateAccount(contract.StrHash(code), bc.sdb.GetStateDB())
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +229,7 @@ func (bc *DummyChain) GetAccountState(name string) (*types.State, error) {
 }
 
 func (bc *DummyChain) GetStaking(name string) (*types.Staking, error) {
-	scs, err := state.GetSystemAccountState(bc.sdb.GetStateDB())
+	scs, err := statedb.GetSystemAccountState(bc.sdb.GetStateDB())
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +448,7 @@ func (l *luaTxDeploy) Constructor(args string) *luaTxDeploy {
 }
 
 func contractFrame(l luaTxContract, bs *state.BlockState, cdb contract.ChainAccessor, receiptTx db.Transaction,
-	run func(s, c *state.AccountState, id types.AccountID, cs *state.ContractState) (string, []*types.Event, *big.Int, error)) error {
+	run func(s, c *state.AccountState, id types.AccountID, cs *statedb.ContractState) (string, []*types.Event, *big.Int, error)) error {
 
 	creatorId := types.ToAccountID(l.sender())
 	creatorState, err := state.GetAccountState(l.sender(), bs.StateDB)
@@ -461,7 +462,7 @@ func contractFrame(l luaTxContract, bs *state.BlockState, cdb contract.ChainAcce
 		return err
 	}
 
-	eContractState, err := state.OpenContractState(l.recipient(), contractState.State(), bs.StateDB)
+	eContractState, err := statedb.OpenContractState(l.recipient(), contractState.State(), bs.StateDB)
 	if err != nil {
 		return err
 	}
@@ -531,7 +532,7 @@ func (l *luaTxDeploy) run(execCtx context.Context, bs *state.BlockState, bc *Dum
 		return l.cErr
 	}
 	return contractFrame(l, bs, bc, receiptTx,
-		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *state.ContractState) (string, []*types.Event, *big.Int, error) {
+		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *statedb.ContractState) (string, []*types.Event, *big.Int, error) {
 			contractV.State().SqlRecoveryPoint = 1
 
 			ctx := contract.NewVmContext(execCtx, bs, nil, sender, contractV, eContractState, sender.ID(), l.Hash(), bi, "", true, false, contractV.State().SqlRecoveryPoint, contract.BlockFactory, l.amount(), math.MaxUint64, false)
@@ -540,7 +541,7 @@ func (l *luaTxDeploy) run(execCtx context.Context, bs *state.BlockState, bc *Dum
 			if err != nil {
 				return "", nil, ctrFee, err
 			}
-			err = state.StageContractState(eContractState, bs.StateDB)
+			err = statedb.StageContractState(eContractState, bs.StateDB)
 			if err != nil {
 				return "", nil, ctrFee, err
 			}
@@ -592,14 +593,14 @@ func (l *luaTxCall) Fail(expectedErr string) *luaTxCall {
 
 func (l *luaTxCall) run(execCtx context.Context, bs *state.BlockState, bc *DummyChain, bi *types.BlockHeaderInfo, receiptTx db.Transaction) error {
 	err := contractFrame(l, bs, bc, receiptTx,
-		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *state.ContractState) (string, []*types.Event, *big.Int, error) {
+		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *statedb.ContractState) (string, []*types.Event, *big.Int, error) {
 			ctx := contract.NewVmContext(execCtx, bs, bc, sender, contractV, eContractState, sender.ID(), l.Hash(), bi, "", true, false, contractV.State().SqlRecoveryPoint, contract.BlockFactory, l.amount(), math.MaxUint64, l.feeDelegate)
 
 			rv, events, ctrFee, err := contract.Call(eContractState, l.payload(), l.recipient(), ctx)
 			if err != nil {
 				return "", nil, ctrFee, err
 			}
-			err = state.StageContractState(eContractState, bs.StateDB)
+			err = statedb.StageContractState(eContractState, bs.StateDB)
 			if err != nil {
 				return "", nil, ctrFee, err
 			}
@@ -674,7 +675,7 @@ func (bc *DummyChain) DisConnectBlock() error {
 }
 
 func (bc *DummyChain) Query(contract_name, queryInfo, expectedErr string, expectedRvs ...string) error {
-	cState, err := state.OpenContractStateAccount(contract.StrHash(contract_name), bc.sdb.GetStateDB())
+	cState, err := statedb.OpenContractStateAccount(contract.StrHash(contract_name), bc.sdb.GetStateDB())
 	if err != nil {
 		return err
 	}
@@ -703,7 +704,7 @@ func (bc *DummyChain) Query(contract_name, queryInfo, expectedErr string, expect
 }
 
 func (bc *DummyChain) QueryOnly(contract_name, queryInfo string, expectedErr string) (bool, string, error) {
-	cState, err := state.OpenContractStateAccount(contract.StrHash(contract_name), bc.sdb.GetStateDB())
+	cState, err := statedb.OpenContractStateAccount(contract.StrHash(contract_name), bc.sdb.GetStateDB())
 	if err != nil {
 		return false, "", err
 	}

--- a/contract/vm_dummy/vm_dummy_test.go
+++ b/contract/vm_dummy/vm_dummy_test.go
@@ -2614,7 +2614,7 @@ func TestFeatureGovernance(t *testing.T) {
 		require.NoErrorf(t, err, "failed to create dummy chain")
 		defer bc.Release()
 
-		err = bc.ConnectBlock(NewLuaTxAccount("user1", 1, types.Aergo), NewLuaTxDeploy("user1", "gov", 0, code))
+		err = bc.ConnectBlock(NewLuaTxAccount("user1", 40000, types.Aergo), NewLuaTxDeploy("user1", "gov", 0, code))
 		require.NoErrorf(t, err, "failed to deploy")
 
 		amount := types.NewAmount(40000, types.Aergo) // 40,000 aergo
@@ -2747,7 +2747,7 @@ func TestFeaturePcallNested(t *testing.T) {
 		defer bc.Release()
 
 		err = bc.ConnectBlock(
-			NewLuaTxAccount("user1", 1, types.Aergo),
+			NewLuaTxAccount("user1", 10, types.Aergo),
 			NewLuaTxAccount("bong", 0, 0),
 			NewLuaTxDeploy("user1", "pcall", uint64(types.Aergo)*10, code),
 		)

--- a/contract/vm_state.go
+++ b/contract/vm_state.go
@@ -12,7 +12,7 @@ import (
 )
 
 type callState struct {
-	ctrState *state.ContractState
+	ctrState *statedb.ContractState
 	accState *state.AccountState
 	tx       sqlTx
 }
@@ -38,7 +38,7 @@ func getCtrState(ctx *vmContext, id []byte) (*callState, error) {
 		return nil, err
 	}
 	if cs.ctrState == nil {
-		cs.ctrState, err = state.OpenContractState(id, cs.accState.State(), ctx.bs.StateDB)
+		cs.ctrState, err = statedb.OpenContractState(id, cs.accState.State(), ctx.bs.StateDB)
 	}
 	return cs, err
 }
@@ -61,10 +61,10 @@ func newContractInfo(cs *callState, sender, contractId []byte, rp uint64, amount
 	}
 }
 
-func getOnlyContractState(ctx *vmContext, id []byte) (*state.ContractState, error) {
+func getOnlyContractState(ctx *vmContext, id []byte) (*statedb.ContractState, error) {
 	cs := ctx.callState[types.ToAccountID(id)]
 	if cs == nil || cs.ctrState == nil {
-		return state.OpenContractStateAccount(id, ctx.bs.StateDB)
+		return statedb.OpenContractStateAccount(id, ctx.bs.StateDB)
 	}
 	return cs.ctrState, nil
 }

--- a/contract/vm_state.go
+++ b/contract/vm_state.go
@@ -12,8 +12,8 @@ import (
 )
 
 type callState struct {
-	isSend   bool
-	isDeploy bool
+	isCallback bool
+	isDeploy   bool
 
 	ctrState *statedb.ContractState
 	accState *state.AccountState
@@ -29,7 +29,7 @@ func getCallState(ctx *vmContext, id []byte) (*callState, error) {
 		if err != nil {
 			return nil, err
 		}
-		cs = &callState{accState: accState}
+		cs = &callState{isCallback: true, accState: accState}
 		ctx.callState[aid] = cs
 	}
 	return cs, nil

--- a/contract/vm_state.go
+++ b/contract/vm_state.go
@@ -12,6 +12,9 @@ import (
 )
 
 type callState struct {
+	isSend   bool
+	isDeploy bool
+
 	ctrState *statedb.ContractState
 	accState *state.AccountState
 	tx       sqlTx

--- a/contract/vm_state.go
+++ b/contract/vm_state.go
@@ -35,7 +35,7 @@ func getCallState(ctx *vmContext, id []byte) (*callState, error) {
 	return cs, nil
 }
 
-func getCtrState(ctx *vmContext, id []byte) (*callState, error) {
+func getContractState(ctx *vmContext, id []byte) (*callState, error) {
 	cs, err := getCallState(ctx, id)
 	if err != nil {
 		return nil, err
@@ -44,6 +44,14 @@ func getCtrState(ctx *vmContext, id []byte) (*callState, error) {
 		cs.ctrState, err = statedb.OpenContractState(id, cs.accState.State(), ctx.bs.StateDB)
 	}
 	return cs, err
+}
+
+func getOnlyContractState(ctx *vmContext, id []byte) (*statedb.ContractState, error) {
+	cs := ctx.callState[types.ToAccountID(id)]
+	if cs == nil || cs.ctrState == nil {
+		return statedb.OpenContractStateAccount(id, ctx.bs.StateDB)
+	}
+	return cs.ctrState, nil
 }
 
 type contractInfo struct {
@@ -62,14 +70,6 @@ func newContractInfo(cs *callState, sender, contractId []byte, rp uint64, amount
 		rp,
 		amount,
 	}
-}
-
-func getOnlyContractState(ctx *vmContext, id []byte) (*statedb.ContractState, error) {
-	cs := ctx.callState[types.ToAccountID(id)]
-	if cs == nil || cs.ctrState == nil {
-		return statedb.OpenContractStateAccount(id, ctx.bs.StateDB)
-	}
-	return cs.ctrState, nil
 }
 
 type recoveryEntry struct {

--- a/contract/vm_state.go
+++ b/contract/vm_state.go
@@ -1,0 +1,146 @@
+package contract
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+
+	"github.com/aergoio/aergo/v2/internal/enc/base58"
+	"github.com/aergoio/aergo/v2/state"
+	"github.com/aergoio/aergo/v2/state/statedb"
+	"github.com/aergoio/aergo/v2/types"
+)
+
+type callState struct {
+	ctrState  *state.ContractState
+	prevState *types.State
+	curState  *types.State
+	tx        sqlTx
+}
+
+func getCallState(ctx *vmContext, id []byte) (*callState, error) {
+	aid := types.ToAccountID(id)
+	cs := ctx.callState[aid]
+	if cs == nil {
+		bs := ctx.bs
+
+		prevState, err := bs.GetAccountState(aid)
+		if err != nil {
+			return nil, err
+		}
+
+		curState := prevState.Clone()
+		cs = &callState{prevState: prevState, curState: curState}
+		ctx.callState[aid] = cs
+	}
+	return cs, nil
+}
+
+func getCtrState(ctx *vmContext, id []byte) (*callState, error) {
+	cs, err := getCallState(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if cs.ctrState == nil {
+		cs.ctrState, err = state.OpenContractState(id, cs.curState, ctx.bs.StateDB)
+	}
+	return cs, err
+}
+
+type contractInfo struct {
+	callState  *callState
+	sender     []byte
+	contractId []byte
+	rp         uint64
+	amount     *big.Int
+}
+
+func newContractInfo(cs *callState, sender, contractId []byte, rp uint64, amount *big.Int) *contractInfo {
+	return &contractInfo{
+		cs,
+		sender,
+		contractId,
+		rp,
+		amount,
+	}
+}
+
+func getOnlyContractState(ctx *vmContext, id []byte) (*state.ContractState, error) {
+	cs := ctx.callState[types.ToAccountID(id)]
+	if cs == nil || cs.ctrState == nil {
+		return state.OpenContractStateAccount(id, ctx.bs.StateDB)
+	}
+	return cs.ctrState, nil
+}
+
+type recoveryEntry struct {
+	seq           int
+	amount        *big.Int
+	senderState   *types.State
+	senderNonce   uint64
+	callState     *callState
+	onlySend      bool
+	isDeploy      bool
+	sqlSaveName   *string
+	stateRevision statedb.Snapshot
+	prev          *recoveryEntry
+}
+
+func (re *recoveryEntry) recovery(bs *state.BlockState) error {
+	var zero big.Int
+	cs := re.callState
+	if re.amount.Cmp(&zero) > 0 {
+		if re.senderState != nil {
+			re.senderState.Balance = new(big.Int).Add(re.senderState.GetBalanceBigInt(), re.amount).Bytes()
+		}
+		if cs != nil {
+			cs.curState.Balance = new(big.Int).Sub(cs.curState.GetBalanceBigInt(), re.amount).Bytes()
+		}
+	}
+	if re.onlySend {
+		return nil
+	}
+	if re.senderState != nil {
+		re.senderState.Nonce = re.senderNonce
+	}
+
+	if cs == nil {
+		return nil
+	}
+	if re.stateRevision != -1 {
+		err := cs.ctrState.Rollback(re.stateRevision)
+		if err != nil {
+			return newDbSystemError(err)
+		}
+		if re.isDeploy {
+			err := cs.ctrState.SetCode(nil)
+			if err != nil {
+				return newDbSystemError(err)
+			}
+			bs.RemoveCache(cs.ctrState.GetAccountID())
+		}
+	}
+	if cs.tx != nil {
+		if re.sqlSaveName == nil {
+			err := cs.tx.rollbackToSavepoint()
+			if err != nil {
+				return newDbSystemError(err)
+			}
+			cs.tx = nil
+		} else {
+			err := cs.tx.rollbackToSubSavepoint(*re.sqlSaveName)
+			if err != nil {
+				return newDbSystemError(err)
+			}
+		}
+	}
+	return nil
+}
+
+func getTraceFile(blkno uint64, tx []byte) *os.File {
+	f, _ := os.OpenFile(fmt.Sprintf("%s%s%d.trace", os.TempDir(), string(os.PathSeparator), blkno), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if f != nil {
+		_, _ = f.WriteString(fmt.Sprintf("[START TX]: %s\n", base58.Encode(tx)))
+	}
+	return f
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -443,7 +443,7 @@ func (mp *MemPool) setStateDB(block *types.Block) (bool, bool) {
 			} else {
 				mp.isPublic = cid.PublicNet
 				if !mp.isPublic {
-					ecs, err := state.GetEnterpriseAccountState(mp.stateDB)
+					ecs, err := statedb.GetEnterpriseAccountState(mp.stateDB)
 					if err != nil {
 						mp.Warn().Err(err).Msg("failed to get whitelist")
 					}
@@ -591,7 +591,7 @@ func (mp *MemPool) getNameDest(account []byte, owner bool) []byte {
 		return account
 	}
 
-	scs, err := state.GetNameAccountState(mp.stateDB)
+	scs, err := statedb.GetNameAccountState(mp.stateDB)
 	if err != nil {
 		mp.Error().Str("for name", string(account)).Msgf("failed to open contract %s", types.AergoName)
 		return nil
@@ -663,7 +663,7 @@ func (mp *MemPool) validateTx(tx types.Transaction, account types.Address) error
 		if err != nil {
 			return err
 		}
-		scs, err := state.OpenContractState(id, aergoState, mp.stateDB)
+		scs, err := statedb.OpenContractState(id, aergoState, mp.stateDB)
 		if err != nil {
 			return err
 		}
@@ -689,7 +689,7 @@ func (mp *MemPool) validateTx(tx types.Transaction, account types.Address) error
 				return err
 			}
 		case types.AergoEnterprise:
-			enterprisecs, err := state.GetEnterpriseAccountState(mp.stateDB)
+			enterprisecs, err := statedb.GetEnterpriseAccountState(mp.stateDB)
 			if err != nil {
 				return err
 			}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -658,12 +658,12 @@ func (mp *MemPool) validateTx(tx types.Transaction, account types.Address) error
 			return types.ErrTxInvalidRecipient
 		}
 	case types.TxType_GOVERNANCE:
-		aergoState, err := mp.getAccountState(tx.GetBody().GetRecipient())
+		id := tx.GetBody().GetRecipient()
+		aergoState, err := mp.getAccountState(id)
 		if err != nil {
 			return err
 		}
-		aid := types.ToAccountID(tx.GetBody().GetRecipient())
-		scs, err := state.OpenContractState(aid, aergoState, mp.stateDB)
+		scs, err := state.OpenContractState(id, aergoState, mp.stateDB)
 		if err != nil {
 			return err
 		}
@@ -795,26 +795,14 @@ func (mp *MemPool) getAccountState(acc []byte) (*types.State, error) {
 		strAcc := aid.String()
 		bal := getBalanceByAccMock(strAcc)
 		nonce := getNonceByAccMock(strAcc)
-		//mp.Error().Str("acc:", strAcc).Int("nonce", int(nonce)).Msg("")
 		return &types.State{Balance: new(big.Int).SetUint64(bal).Bytes(), Nonce: nonce}, nil
 	}
 
 	state, err := mp.stateDB.GetAccountState(types.ToAccountID(acc))
-
 	if err != nil {
 		mp.Fatal().Err(err).Str("sroot", base58.Encode(mp.stateDB.GetRoot())).Msg("failed to get state")
-
-		//FIXME PANIC?
-		//mp.Fatal().Err(err).Msg("failed to get state")
 		return nil, err
 	}
-	/*
-		if state.Balance == 0 {
-			strAcc := types.EncodeAddress(acc)
-			mp.Info().Str("address", strAcc).Msg("w t f")
-
-		}
-	*/
 	return state, nil
 }
 

--- a/state/account.go
+++ b/state/account.go
@@ -42,7 +42,17 @@ func (as *AccountState) SetNonce(nonce uint64) {
 	as.newState.Nonce = nonce
 }
 
+func (as *AccountState) Nonce() uint64 {
+	if as.newState == nil {
+		return 0
+	}
+	return as.newState.Nonce
+}
+
 func (as *AccountState) Balance() *big.Int {
+	if as.newState == nil {
+		return big.NewInt(0)
+	}
 	return new(big.Int).SetBytes(as.newState.Balance)
 }
 
@@ -56,8 +66,37 @@ func (as *AccountState) SubBalance(amount *big.Int) {
 	as.newState.Balance = new(big.Int).Sub(balance, amount).Bytes()
 }
 
-func (as *AccountState) RP() uint64 {
+func (as *AccountState) SetCodeHash(codeHash []byte) {
+	as.newState.CodeHash = codeHash
+}
+
+func (as *AccountState) CodeHash() []byte {
+	if as.newState == nil {
+		return nil
+	}
+	return as.newState.CodeHash
+}
+
+func (as *AccountState) SetRP() uint64 {
 	return as.newState.SqlRecoveryPoint
+}
+
+func (as *AccountState) RP() uint64 {
+	if as.newState == nil {
+		return 0
+	}
+	return as.newState.SqlRecoveryPoint
+}
+
+func (as *AccountState) SetStorageRoot(storageRoot []byte) {
+	as.newState.StorageRoot = storageRoot
+}
+
+func (as *AccountState) StorageRoot() []byte {
+	if as.newState == nil {
+		return nil
+	}
+	return as.newState.StorageRoot
 }
 
 func (as *AccountState) IsNew() bool {
@@ -144,12 +183,12 @@ func GetAccountState(id []byte, states *statedb.StateDB) (*AccountState, error) 
 	}, nil
 }
 
-func InitAccountState(id []byte, sdb *statedb.StateDB, old *types.State, new *types.State) *AccountState {
+func InitAccountState(id []byte, sdb *statedb.StateDB, stOld, stNew *types.State) *AccountState {
 	return &AccountState{
 		sdb:      sdb,
 		id:       id,
 		aid:      types.ToAccountID(id),
-		oldState: old,
-		newState: new,
+		oldState: stOld,
+		newState: stNew,
 	}
 }

--- a/state/account.go
+++ b/state/account.go
@@ -125,10 +125,6 @@ func (as *AccountState) PutState() error {
 	return as.sdb.PutState(as.aid, as.newState)
 }
 
-func (as *AccountState) ClearAid() {
-	as.aid = statedb.EmptyAccountID
-}
-
 //----------------------------------------------------------------------------------------------//
 // global functions
 

--- a/state/account.go
+++ b/state/account.go
@@ -25,8 +25,12 @@ const (
 
 func (as *AccountState) ID() []byte {
 	if len(as.id) < types.AddressLength {
-		as.id = types.AddressPadding(as.id)
+		return types.AddressPadding(as.id)
 	}
+	return as.IDNoPadding()
+}
+
+func (as *AccountState) IDNoPadding() []byte {
 	return as.id
 }
 

--- a/state/account.go
+++ b/state/account.go
@@ -75,8 +75,8 @@ func (as *AccountState) CodeHash() []byte {
 	return as.newState.CodeHash
 }
 
-func (as *AccountState) SetRP() uint64 {
-	return as.newState.SqlRecoveryPoint
+func (as *AccountState) SetRP(sqlRecoveryPoint uint64) {
+	as.newState.SqlRecoveryPoint = sqlRecoveryPoint
 }
 
 func (as *AccountState) RP() uint64 {

--- a/state/account.go
+++ b/state/account.go
@@ -47,16 +47,10 @@ func (as *AccountState) SetNonce(nonce uint64) {
 }
 
 func (as *AccountState) Nonce() uint64 {
-	if as.newState == nil {
-		return 0
-	}
 	return as.newState.Nonce
 }
 
 func (as *AccountState) Balance() *big.Int {
-	if as.newState == nil {
-		return big.NewInt(0)
-	}
 	return new(big.Int).SetBytes(as.newState.Balance)
 }
 
@@ -198,11 +192,11 @@ func InitAccountState(id []byte, sdb *statedb.StateDB, stOld, stNew *types.State
 }
 
 func SendBalance(sender, receiver *AccountState, amount *big.Int) error {
-	if sender == receiver {
+	if sender.AccountID() == receiver.AccountID() {
 		return nil
 	}
 	if sender.Balance().Cmp(amount) < 0 {
-		return fmt.Errorf("insufficient balance")
+		return types.ErrInsufficientBalance
 	}
 	sender.SubBalance(amount)
 	receiver.AddBalance(amount)

--- a/state/account.go
+++ b/state/account.go
@@ -196,3 +196,15 @@ func InitAccountState(id []byte, sdb *statedb.StateDB, stOld, stNew *types.State
 		newState: stNew,
 	}
 }
+
+func SendBalance(sender, receiver *AccountState, amount *big.Int) error {
+	if sender == receiver {
+		return nil
+	}
+	if sender.Balance().Cmp(amount) < 0 {
+		return fmt.Errorf("insufficient balance")
+	}
+	sender.SubBalance(amount)
+	receiver.AddBalance(amount)
+	return nil
+}

--- a/state/account_test.go
+++ b/state/account_test.go
@@ -1,0 +1,33 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/aergoio/aergo/v2/internal/enc/base58"
+	"github.com/aergoio/aergo/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAidWithPadding(t *testing.T) {
+	for _, test := range []struct {
+		padding   bool
+		id        []byte
+		expectAid string
+	}{
+		{false, []byte(types.AergoName), "55EYudcSHptibgAWjhJGEFXzti7ggpgQTCCBgyeCa2hR"},
+		{true, []byte(types.AergoName), "DkAm9mQvmRDCqAPARNhwjyrvGPgrGYmErpov8S9sbkc3"},
+		{false, base58.DecodeOrNil("AmLrV7tg69KE5ZQehkjGiA7yJyDxJ25uyF96PMRptfzwozhAJbaK"), "6eULcXBWJMgjCMeGybbpfoPWVwyuidMFFjsrJJvXmF7z"},
+		{true, base58.DecodeOrNil("AmLrV7tg69KE5ZQehkjGiA7yJyDxJ25uyF96PMRptfzwozhAJbaK"), "6eULcXBWJMgjCMeGybbpfoPWVwyuidMFFjsrJJvXmF7z"},
+	} {
+		as := &AccountState{
+			id: test.id,
+		}
+		var aid types.AccountID
+		if test.padding {
+			aid = types.ToAccountID(as.ID())
+		} else {
+			aid = types.ToAccountID(as.IDNoPadding())
+		}
+		require.Equal(t, test.expectAid, aid.String())
+	}
+}

--- a/state/chain.go
+++ b/state/chain.go
@@ -83,11 +83,6 @@ func (sdb *ChainStateDB) GetStateDB() *statedb.StateDB {
 	return sdb.states
 }
 
-// GetSystemAccountState returns the state of the aergo system account.
-func (sdb *ChainStateDB) GetSystemAccountState() (*statedb.ContractState, error) {
-	return statedb.GetSystemAccountState(sdb.GetStateDB())
-}
-
 // OpenNewStateDB returns new instance of statedb given state root hash
 func (sdb *ChainStateDB) OpenNewStateDB(root []byte) *statedb.StateDB {
 	return statedb.NewStateDB(sdb.store, root, sdb.testmode)
@@ -108,7 +103,7 @@ func (sdb *ChainStateDB) SetGenesis(genesis *types.Genesis, bpInit func(*statedb
 		}
 
 		aid := types.ToAccountID([]byte(types.AergoSystem))
-		scs, err := sdb.GetSystemAccountState()
+		scs, err := statedb.GetSystemAccountState(stateDB)
 		if err != nil {
 			return err
 		}

--- a/state/chain.go
+++ b/state/chain.go
@@ -84,8 +84,8 @@ func (sdb *ChainStateDB) GetStateDB() *statedb.StateDB {
 }
 
 // GetSystemAccountState returns the state of the aergo system account.
-func (sdb *ChainStateDB) GetSystemAccountState() (*ContractState, error) {
-	return GetSystemAccountState(sdb.GetStateDB())
+func (sdb *ChainStateDB) GetSystemAccountState() (*statedb.ContractState, error) {
+	return statedb.GetSystemAccountState(sdb.GetStateDB())
 }
 
 // OpenNewStateDB returns new instance of statedb given state root hash
@@ -108,7 +108,7 @@ func (sdb *ChainStateDB) SetGenesis(genesis *types.Genesis, bpInit func(*statedb
 		}
 
 		aid := types.ToAccountID([]byte(types.AergoSystem))
-		scs, err := GetSystemAccountState(stateDB)
+		scs, err := sdb.GetSystemAccountState()
 		if err != nil {
 			return err
 		}

--- a/state/contract.go
+++ b/state/contract.go
@@ -55,8 +55,9 @@ func (cs *ContractState) GetAccountID() types.AccountID {
 }
 
 func (cs *ContractState) GetID() []byte {
-	if len(cs.id) < types.AddressLength {
-		cs.id = types.AddressPadding(cs.id)
+	idPadding := types.AddressPadding(cs.id)
+	if cs.account.String() == types.ToAccountID(idPadding).String() {
+		return idPadding
 	}
 	return cs.id
 }

--- a/state/contract_test.go
+++ b/state/contract_test.go
@@ -33,7 +33,7 @@ func TestContractStateCode(t *testing.T) {
 	testBytes := []byte("test_bytes")
 
 	// open contract state
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// set code
@@ -54,7 +54,7 @@ func TestContractStateData(t *testing.T) {
 	testKey := []byte("test_key")
 
 	// open contract state
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// set data
@@ -79,7 +79,7 @@ func TestContractStateInitialData(t *testing.T) {
 	testKey := []byte("test_key")
 
 	// open contract state
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// get initial data
@@ -112,7 +112,7 @@ func TestContractStateInitialData(t *testing.T) {
 	assert.NoError(t, err, "commit statedb")
 
 	// reopen contract state
-	contractState, err = OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err = OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// get initial data
@@ -129,7 +129,7 @@ func TestContractStateDataDelete(t *testing.T) {
 	testKey := []byte("test_key")
 
 	// open contract state and set test data
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 	err = contractState.SetData(testKey, testBytes)
 	assert.NoError(t, err, "set data to contract state")
@@ -137,7 +137,7 @@ func TestContractStateDataDelete(t *testing.T) {
 	// stage and re-open contract state
 	err = StageContractState(contractState, stateDB)
 	assert.NoError(t, err, "stage contract state")
-	contractState, err = OpenContractState(types.ToAccountID(testAddress), contractState.State, stateDB)
+	contractState, err = OpenContractState(testAddress, contractState.State, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// get and delete test data
@@ -150,7 +150,7 @@ func TestContractStateDataDelete(t *testing.T) {
 	// stage and re-open contract state
 	err = StageContractState(contractState, stateDB)
 	assert.NoError(t, err, "stage contract state")
-	contractState, err = OpenContractState(types.ToAccountID(testAddress), contractState.State, stateDB)
+	contractState, err = OpenContractState(testAddress, contractState.State, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// get test data
@@ -171,7 +171,7 @@ func TestContractStateHasKey(t *testing.T) {
 	testKey := []byte("test_key")
 
 	// open contract state and set test data
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 	assert.False(t, contractState.HasKey(testKey))
 
@@ -200,7 +200,7 @@ func TestContractStateHasKey(t *testing.T) {
 	assert.NoError(t, err, "failed to commit stateDB")
 
 	// re-open contract state
-	contractState, err = OpenContractState(types.ToAccountID(testAddress), contractState.State, stateDB)
+	contractState, err = OpenContractState(testAddress, contractState.State, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// check key existence
@@ -213,7 +213,7 @@ func TestContractStateEmpty(t *testing.T) {
 	testAddress := []byte("test_address")
 
 	// open contract state
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// stage contract state
@@ -229,7 +229,7 @@ func TestContractStateReOpenData(t *testing.T) {
 	testKey := []byte("test_key")
 
 	// open contract state
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// set data
@@ -246,8 +246,8 @@ func TestContractStateReOpenData(t *testing.T) {
 	assert.NoError(t, err, "stage contract state")
 
 	// re-open contract state
-	//contractState2, err := chainOpenContractStateAccount(types.ToAccountID(testAddress),StateDB)
-	contractState2, err := OpenContractState(types.ToAccountID(testAddress), contractState.State, stateDB)
+	//contractState2, err := chainOpenContractStateAccount(testAddress,StateDB)
+	contractState2, err := OpenContractState(testAddress, contractState.State, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// get data
@@ -264,7 +264,7 @@ func TestContractStateRollback(t *testing.T) {
 	testKey := []byte("test_key")
 
 	// open contract state
-	contractState, err := OpenContractStateAccount(types.ToAccountID(testAddress), stateDB)
+	contractState, err := OpenContractStateAccount(testAddress, stateDB)
 	assert.NoError(t, err, "could not open contract state")
 
 	// test data

--- a/state/statedb/contract.go
+++ b/state/statedb/contract.go
@@ -1,4 +1,4 @@
-package state
+package statedb
 
 import (
 	"bytes"
@@ -6,7 +6,6 @@ import (
 	"github.com/aergoio/aergo-lib/db"
 	"github.com/aergoio/aergo/v2/internal/common"
 	"github.com/aergoio/aergo/v2/internal/enc/proto"
-	"github.com/aergoio/aergo/v2/state/statedb"
 	"github.com/aergoio/aergo/v2/types"
 )
 
@@ -15,7 +14,7 @@ type ContractState struct {
 	id      []byte
 	account types.AccountID
 	code    []byte
-	storage *statedb.BufferedStorage
+	storage *bufferedStorage
 	store   db.DB
 }
 
@@ -38,12 +37,12 @@ func (cs *ContractState) GetCode() ([]byte, error) {
 		// already loaded.
 		return cs.code, nil
 	}
-	codeHash := cs.State.GetCodeHash()
+	codeHash := cs.GetCodeHash()
 	if codeHash == nil {
 		// not defined. do nothing.
 		return nil, nil
 	}
-	err := statedb.LoadData(cs.store, cs.State.GetCodeHash(), &cs.code)
+	err := loadData(cs.store, cs.State.GetCodeHash(), &cs.code)
 	if err != nil {
 		return nil, err
 	}
@@ -64,13 +63,13 @@ func (cs *ContractState) GetID() []byte {
 
 // SetRawKV saves (key, value) to st.store without any kind of encoding.
 func (cs *ContractState) SetRawKV(key []byte, value []byte) error {
-	return statedb.SaveData(cs.store, key, value)
+	return saveData(cs.store, key, value)
 }
 
 // GetRawKV loads (key, value) from st.store.
 func (cs *ContractState) GetRawKV(key []byte) ([]byte, error) {
 	var b []byte
-	if err := statedb.LoadData(cs.store, key, &b); err != nil {
+	if err := loadData(cs.store, key, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -78,19 +77,19 @@ func (cs *ContractState) GetRawKV(key []byte) ([]byte, error) {
 
 // HasKey returns existence of the key
 func (cs *ContractState) HasKey(key []byte) bool {
-	return cs.storage.Has(types.GetHashID(key), true)
+	return cs.storage.has(types.GetHashID(key), true)
 }
 
 // SetData store key and value pair to the storage.
 func (cs *ContractState) SetData(key, value []byte) error {
-	cs.storage.Put(statedb.NewValueEntry(types.GetHashID(key), value))
+	cs.storage.put(newValueEntry(types.GetHashID(key), value))
 	return nil
 }
 
 // GetData returns the value corresponding to the key from the buffered storage.
 func (cs *ContractState) GetData(key []byte) ([]byte, error) {
 	id := types.GetHashID(key)
-	if entry := cs.storage.Get(id); entry != nil {
+	if entry := cs.storage.get(id); entry != nil {
 		if value := entry.Value(); value != nil {
 			return value.([]byte), nil
 		}
@@ -108,7 +107,7 @@ func (cs *ContractState) getInitialData(id []byte) ([]byte, error) {
 		return nil, nil
 	}
 	value := []byte{}
-	if err := statedb.LoadData(cs.store, dkey, &value); err != nil {
+	if err := loadData(cs.store, dkey, &value); err != nil {
 		return nil, err
 	}
 	return value, nil
@@ -122,23 +121,23 @@ func (cs *ContractState) GetInitialData(key []byte) ([]byte, error) {
 
 // DeleteData remove key and value pair from the storage.
 func (cs *ContractState) DeleteData(key []byte) error {
-	cs.storage.Put(statedb.NewValueEntryDelete(types.GetHashID(key)))
+	cs.storage.put(newValueEntryDelete(types.GetHashID(key)))
 	return nil
 }
 
 // Snapshot returns revision number of storage buffer
-func (cs *ContractState) Snapshot() statedb.Snapshot {
-	return statedb.Snapshot(cs.storage.Buffer.Snapshot())
+func (cs *ContractState) Snapshot() Snapshot {
+	return Snapshot(cs.storage.Buffer.snapshot())
 }
 
 // Rollback discards changes of storage buffer to revision number
-func (cs *ContractState) Rollback(revision statedb.Snapshot) error {
-	return cs.storage.Buffer.Rollback(int(revision))
+func (cs *ContractState) Rollback(revision Snapshot) error {
+	return cs.storage.Buffer.rollback(int(revision))
 }
 
 // Hash implements types.ImplHashBytes
 func (cs *ContractState) Hash() []byte {
-	return statedb.GetHashBytes(cs.State)
+	return getHashBytes(cs.State)
 }
 
 // Marshal implements types.ImplMarshal
@@ -146,14 +145,14 @@ func (cs *ContractState) Marshal() ([]byte, error) {
 	return proto.Encode(cs.State)
 }
 
-func (cs *ContractState) cache() *statedb.StateBuffer {
+func (cs *ContractState) cache() *stateBuffer {
 	return cs.storage.Buffer
 }
 
 //---------------------------------------------------------------//
 // global functions
 
-func OpenContractStateAccount(id []byte, states *statedb.StateDB) (*ContractState, error) {
+func OpenContractStateAccount(id []byte, states *StateDB) (*ContractState, error) {
 	aid := types.ToAccountID(id)
 	st, err := states.GetAccountState(aid)
 	if err != nil {
@@ -162,12 +161,12 @@ func OpenContractStateAccount(id []byte, states *statedb.StateDB) (*ContractStat
 	return OpenContractState(id, st, states)
 }
 
-func OpenContractState(id []byte, st *types.State, states *statedb.StateDB) (*ContractState, error) {
+func OpenContractState(id []byte, st *types.State, states *StateDB) (*ContractState, error) {
 	aid := types.ToAccountID(id)
-	storage := states.Cache.Get(aid)
+	storage := states.Cache.get(aid)
 	if storage == nil {
 		root := common.Compactz(st.StorageRoot)
-		storage = statedb.NewBufferedStorage(root, states.Store)
+		storage = newBufferedStorage(root, states.Store)
 	}
 	res := &ContractState{
 		State:   st,
@@ -179,23 +178,23 @@ func OpenContractState(id []byte, st *types.State, states *statedb.StateDB) (*Co
 	return res, nil
 }
 
-func StageContractState(st *ContractState, states *statedb.StateDB) error {
-	states.Cache.Put(st.account, st.storage)
+func StageContractState(st *ContractState, states *StateDB) error {
+	states.Cache.put(st.account, st.storage)
 	st.storage = nil
 	return nil
 }
 
 // GetSystemAccountState returns the ContractState of the AERGO system account.
-func GetSystemAccountState(states *statedb.StateDB) (*ContractState, error) {
+func GetSystemAccountState(states *StateDB) (*ContractState, error) {
 	return OpenContractStateAccount([]byte(types.AergoSystem), states)
 }
 
 // GetNameAccountState returns the ContractState of the AERGO name account.
-func GetNameAccountState(states *statedb.StateDB) (*ContractState, error) {
+func GetNameAccountState(states *StateDB) (*ContractState, error) {
 	return OpenContractStateAccount([]byte(types.AergoName), states)
 }
 
 // GetEnterpriseAccountState returns the ContractState of the AERGO enterprise account.
-func GetEnterpriseAccountState(states *statedb.StateDB) (*ContractState, error) {
+func GetEnterpriseAccountState(states *StateDB) (*ContractState, error) {
 	return OpenContractStateAccount([]byte(types.AergoEnterprise), states)
 }

--- a/state/statedb/contract.go
+++ b/state/statedb/contract.go
@@ -54,10 +54,6 @@ func (cs *ContractState) GetAccountID() types.AccountID {
 }
 
 func (cs *ContractState) GetID() []byte {
-	idPadding := types.AddressPadding(cs.id)
-	if cs.account.String() == types.ToAccountID(idPadding).String() {
-		return idPadding
-	}
 	return cs.id
 }
 

--- a/state/statedb/contract_test.go
+++ b/state/statedb/contract_test.go
@@ -1,31 +1,11 @@
-package state
+package statedb
 
 import (
-	"os"
 	"testing"
 
-	"github.com/aergoio/aergo-lib/db"
-	"github.com/aergoio/aergo/v2/state/statedb"
-	"github.com/aergoio/aergo/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 
-var chainStateDB *ChainStateDB
-var stateDB *statedb.StateDB
-
-func initTest(t *testing.T) {
-	chainStateDB = NewChainStateDB()
-	_ = chainStateDB.Init(string(db.BadgerImpl), "test", nil, false)
-	stateDB = chainStateDB.GetStateDB()
-	genesis := types.GetTestGenesis()
-
-	err := chainStateDB.SetGenesis(genesis, nil)
-	assert.NoError(t, err, "failed init")
-}
-func deinitTest() {
-	_ = chainStateDB.Close()
-	_ = os.RemoveAll("test")
-}
 func TestContractStateCode(t *testing.T) {
 	initTest(t)
 	defer deinitTest()
@@ -291,7 +271,7 @@ func TestContractStateRollback(t *testing.T) {
 	assert.Equal(t, []byte("2"), res)
 
 	// rollback to empty: rev 0
-	contractState.Rollback(statedb.Snapshot(0))
+	contractState.Rollback(Snapshot(0))
 	res, _ = contractState.GetData(testKey)
 	assert.Nil(t, res)
 }

--- a/state/statedb/statebuffer_test.go
+++ b/state/statedb/statebuffer_test.go
@@ -81,71 +81,71 @@ func TestBufferIndexRollback(t *testing.T) {
 }
 
 func TestBufferRollback(t *testing.T) {
-	stb := NewStateBuffer()
+	stb := newStateBuffer()
 
-	assert.Equal(t, 0, stb.Snapshot())
-	stb.Put(NewValueEntry(k0, []byte{1})) // rev 1: k0=1
-	stb.Put(NewValueEntry(k0, []byte{2})) // rev 2: k0=2
-	stb.Put(NewValueEntry(k0, []byte{3})) // rev 3: k0=3
-	stb.Put(NewValueEntry(k0, []byte{4})) // rev 4: k0=4
-	stb.Put(NewValueEntry(k1, []byte{1})) // rev 5: k0=4, k1=1
-	stb.Put(NewValueEntry(k1, []byte{2})) // rev 6: k0=4, k1=2
-	stb.Put(NewValueEntry(k1, []byte{3})) // rev 7: k0=4, k1=3
+	assert.Equal(t, 0, stb.snapshot())
+	stb.put(newValueEntry(k0, []byte{1})) // rev 1: k0=1
+	stb.put(newValueEntry(k0, []byte{2})) // rev 2: k0=2
+	stb.put(newValueEntry(k0, []byte{3})) // rev 3: k0=3
+	stb.put(newValueEntry(k0, []byte{4})) // rev 4: k0=4
+	stb.put(newValueEntry(k1, []byte{1})) // rev 5: k0=4, k1=1
+	stb.put(newValueEntry(k1, []byte{2})) // rev 6: k0=4, k1=2
+	stb.put(newValueEntry(k1, []byte{3})) // rev 7: k0=4, k1=3
 
 	// snapshot revision 7
-	revision := stb.Snapshot() // 7
-	assert.Equal(t, 7, stb.Snapshot())
+	revision := stb.snapshot() // 7
+	assert.Equal(t, 7, stb.snapshot())
 
-	stb.Put(NewValueEntry(k0, []byte{5})) // rev 8: k0=5, k1=3
-	stb.Put(NewValueEntry(k0, []byte{6})) // rev 9: k0=6, k1=3
-	assert.Equal(t, []byte{6}, stb.Get(k0).Value())
-	assert.Equal(t, []byte{3}, stb.Get(k1).Value())
-	t.Logf("k0: %v, k1: %v", stb.Get(k0).Value(), stb.Get(k1).Value())
+	stb.put(newValueEntry(k0, []byte{5})) // rev 8: k0=5, k1=3
+	stb.put(newValueEntry(k0, []byte{6})) // rev 9: k0=6, k1=3
+	assert.Equal(t, []byte{6}, stb.get(k0).Value())
+	assert.Equal(t, []byte{3}, stb.get(k1).Value())
+	t.Logf("k0: %v, k1: %v", stb.get(k0).Value(), stb.get(k1).Value())
 
 	// rollback to revision 7
-	stb.Rollback(revision)
-	assert.Equal(t, 7, stb.Snapshot())
+	stb.rollback(revision)
+	assert.Equal(t, 7, stb.snapshot())
 
-	assert.Equal(t, []byte{4}, stb.Get(k0).Value())
-	assert.Equal(t, []byte{3}, stb.Get(k1).Value())
-	t.Logf("k0: %v, k1: %v", stb.Get(k0).Value(), stb.Get(k1).Value())
+	assert.Equal(t, []byte{4}, stb.get(k0).Value())
+	assert.Equal(t, []byte{3}, stb.get(k1).Value())
+	t.Logf("k0: %v, k1: %v", stb.get(k0).Value(), stb.get(k1).Value())
 
-	stb.Put(NewValueEntry(k1, []byte{4})) // rev 8: k0=4, k1=4
-	stb.Put(NewValueEntry(k1, []byte{5})) // rev 9: k0=4, k1=5
-	stb.Put(NewValueEntry(k0, []byte{7})) // rev 10: k0=7, k1=5
+	stb.put(newValueEntry(k1, []byte{4})) // rev 8: k0=4, k1=4
+	stb.put(newValueEntry(k1, []byte{5})) // rev 9: k0=4, k1=5
+	stb.put(newValueEntry(k0, []byte{7})) // rev 10: k0=7, k1=5
 
 	// snapshot revision 10
-	revision = stb.Snapshot() // 10
-	assert.Equal(t, 10, stb.Snapshot())
+	revision = stb.snapshot() // 10
+	assert.Equal(t, 10, stb.snapshot())
 
-	stb.Put(NewValueEntry(k0, []byte{8})) // rev 11: k0=8, k1=5
-	stb.Put(NewValueEntry(k1, []byte{6})) // rev 12: k0=8, k1=6
-	assert.Equal(t, []byte{8}, stb.Get(k0).Value())
-	assert.Equal(t, []byte{6}, stb.Get(k1).Value())
-	t.Logf("k0: %v, k1: %v", stb.Get(k0).Value(), stb.Get(k1).Value())
+	stb.put(newValueEntry(k0, []byte{8})) // rev 11: k0=8, k1=5
+	stb.put(newValueEntry(k1, []byte{6})) // rev 12: k0=8, k1=6
+	assert.Equal(t, []byte{8}, stb.get(k0).Value())
+	assert.Equal(t, []byte{6}, stb.get(k1).Value())
+	t.Logf("k0: %v, k1: %v", stb.get(k0).Value(), stb.get(k1).Value())
 
 	// rollback to revision 10
-	stb.Rollback(revision) // 10
-	assert.Equal(t, 10, stb.Snapshot())
+	stb.rollback(revision) // 10
+	assert.Equal(t, 10, stb.snapshot())
 
-	assert.Equal(t, []byte{7}, stb.Get(k0).Value())
-	assert.Equal(t, []byte{5}, stb.Get(k1).Value())
-	t.Logf("k0: %v, k1: %v", stb.Get(k0).Value(), stb.Get(k1).Value())
+	assert.Equal(t, []byte{7}, stb.get(k0).Value())
+	assert.Equal(t, []byte{5}, stb.get(k1).Value())
+	t.Logf("k0: %v, k1: %v", stb.get(k0).Value(), stb.get(k1).Value())
 }
 
 func TestBufferHasKey(t *testing.T) {
-	stb := NewStateBuffer()
-	assert.False(t, stb.Has(k0))
+	stb := newStateBuffer()
+	assert.False(t, stb.has(k0))
 
-	stb.Put(NewValueEntry(k0, []byte{1}))
-	assert.True(t, stb.Has(k0)) // buffer has key
+	stb.put(newValueEntry(k0, []byte{1}))
+	assert.True(t, stb.has(k0)) // buffer has key
 
-	stb.Put(NewValueEntryDelete(k0))
-	assert.True(t, stb.Has(k0)) // buffer has key for ValueEntryDelete
+	stb.put(newValueEntryDelete(k0))
+	assert.True(t, stb.has(k0)) // buffer has key for ValueEntryDelete
 
-	stb.Put(NewValueEntry(k0, []byte{2}))
-	assert.True(t, stb.Has(k0)) // buffer has key
+	stb.put(newValueEntry(k0, []byte{2}))
+	assert.True(t, stb.has(k0)) // buffer has key
 
-	stb.Reset()
-	assert.False(t, stb.Has(k0)) // buffer doesn't have key
+	stb.reset()
+	assert.False(t, stb.has(k0)) // buffer doesn't have key
 }

--- a/state/statedb/statedata.go
+++ b/state/statedb/statedata.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aergoio/aergo/v2/types"
 )
 
-func SaveData(store db.DB, key []byte, data interface{}) error {
+func saveData(store db.DB, key []byte, data interface{}) error {
 	if key == nil {
 		return errSaveData
 	}
@@ -31,7 +31,7 @@ func SaveData(store db.DB, key []byte, data interface{}) error {
 	return nil
 }
 
-func LoadData(store db.DB, key []byte, data interface{}) error {
+func loadData(store db.DB, key []byte, data interface{}) error {
 	if key == nil {
 		return errLoadData
 	}
@@ -57,7 +57,7 @@ func (states *StateDB) loadStateData(key []byte) (*types.State, error) {
 		return nil, errLoadStateData
 	}
 	data := &types.State{}
-	if err := LoadData(states.Store, key, data); err != nil {
+	if err := loadData(states.Store, key, data); err != nil {
 		return nil, err
 	}
 	return data, nil

--- a/state/statedb/statedata_test.go
+++ b/state/statedb/statedata_test.go
@@ -35,13 +35,13 @@ func TestStateDataBasic(t *testing.T) {
 	defer deinitTest()
 
 	// save data
-	if err := SaveData(store, testKey, testData); err != nil {
+	if err := saveData(store, testKey, testData); err != nil {
 		t.Errorf("failed to save data: %v", err.Error())
 	}
 
 	// load data
 	data := []byte{}
-	if err := LoadData(store, testKey, &data); err != nil {
+	if err := loadData(store, testKey, &data); err != nil {
 		t.Errorf("failed to load data: %v", err.Error())
 	}
 	assert.NotNil(t, data)
@@ -55,7 +55,7 @@ func TestStateDataNil(t *testing.T) {
 	// load data before saving
 	var data interface{}
 	assert.Nil(t, data)
-	if err := LoadData(store, testKey, &data); err != nil {
+	if err := loadData(store, testKey, &data); err != nil {
 		t.Errorf("failed to load data: %v", err.Error())
 	}
 	assert.Nil(t, data)
@@ -67,13 +67,13 @@ func TestStateDataEmpty(t *testing.T) {
 
 	// save empty data
 	var testEmpty []byte
-	if err := SaveData(store, testKey, testEmpty); err != nil {
+	if err := saveData(store, testKey, testEmpty); err != nil {
 		t.Errorf("failed to save nil data: %v", err.Error())
 	}
 
 	// load empty data
 	data := []byte{}
-	if err := LoadData(store, testKey, &data); err != nil {
+	if err := loadData(store, testKey, &data); err != nil {
 		t.Errorf("failed to load data: %v", err.Error())
 	}
 	assert.NotNil(t, data)
@@ -85,18 +85,18 @@ func TestStateDataOverwrite(t *testing.T) {
 	defer deinitTest()
 
 	// save data
-	if err := SaveData(store, testKey, testData); err != nil {
+	if err := saveData(store, testKey, testData); err != nil {
 		t.Errorf("failed to save data: %v", err.Error())
 	}
 
 	// save another data to same key
-	if err := SaveData(store, testKey, testOver); err != nil {
+	if err := saveData(store, testKey, testOver); err != nil {
 		t.Errorf("failed to overwrite data: %v", err.Error())
 	}
 
 	// load data
 	data := []byte{}
-	if err := LoadData(store, testKey, &data); err != nil {
+	if err := loadData(store, testKey, &data); err != nil {
 		t.Errorf("failed to load data: %v", err.Error())
 	}
 	assert.NotNil(t, data)

--- a/state/statedb/storage_test.go
+++ b/state/statedb/storage_test.go
@@ -12,111 +12,111 @@ import (
 // }
 
 func TestStorageBasic(t *testing.T) {
-	storage := NewBufferedStorage(nil, nil)
+	storage := newBufferedStorage(nil, nil)
 	v1 := types.GetHashID([]byte("v1"))
 	v2 := types.GetHashID([]byte("v2"))
 
-	storage.Checkpoint(0)
-	storage.Put(NewValueEntry(v1, []byte{1})) // rev 1
+	storage.checkpoint(0)
+	storage.put(newValueEntry(v1, []byte{1})) // rev 1
 
-	storage.Checkpoint(1)
-	storage.Put(NewValueEntry(v2, []byte{2})) // rev 3
+	storage.checkpoint(1)
+	storage.put(newValueEntry(v2, []byte{2})) // rev 3
 
-	storage.Checkpoint(2)
-	storage.Put(NewValueEntry(v1, []byte{3})) // rev 5
-	storage.Put(NewValueEntry(v2, []byte{4})) // rev 6
-	storage.Put(NewValueEntry(v2, []byte{5})) // rev 7
+	storage.checkpoint(2)
+	storage.put(newValueEntry(v1, []byte{3})) // rev 5
+	storage.put(newValueEntry(v2, []byte{4})) // rev 6
+	storage.put(newValueEntry(v2, []byte{5})) // rev 7
 
-	storage.Checkpoint(3)
-	storage.Put(NewValueEntry(v1, []byte{6})) // rev 9
-	storage.Put(NewValueEntry(v2, []byte{7})) // rev 10
+	storage.checkpoint(3)
+	storage.put(newValueEntry(v1, []byte{6})) // rev 9
+	storage.put(newValueEntry(v2, []byte{7})) // rev 10
 
-	t.Log("v1", storage.Get(v1).Value(), "v2", storage.Get(v2).Value())
-	assert.Equal(t, []byte{6}, storage.Get(v1).Value())
-	assert.Equal(t, []byte{7}, storage.Get(v2).Value())
+	t.Log("v1", storage.get(v1).Value(), "v2", storage.get(v2).Value())
+	assert.Equal(t, []byte{6}, storage.get(v1).Value())
+	assert.Equal(t, []byte{7}, storage.get(v2).Value())
 
-	storage.Rollback(3)
-	t.Log("v1", storage.Get(v1).Value(), "v2", storage.Get(v2).Value())
-	assert.Equal(t, []byte{3}, storage.Get(v1).Value())
-	assert.Equal(t, []byte{5}, storage.Get(v2).Value())
+	storage.rollback(3)
+	t.Log("v1", storage.get(v1).Value(), "v2", storage.get(v2).Value())
+	assert.Equal(t, []byte{3}, storage.get(v1).Value())
+	assert.Equal(t, []byte{5}, storage.get(v2).Value())
 
-	storage.Rollback(1)
-	t.Log("v1", storage.Get(v1).Value(), "v2", storage.Get(v2))
-	assert.Equal(t, []byte{1}, storage.Get(v1).Value())
-	assert.Nil(t, storage.Get(v2))
+	storage.rollback(1)
+	t.Log("v1", storage.get(v1).Value(), "v2", storage.get(v2))
+	assert.Equal(t, []byte{1}, storage.get(v1).Value())
+	assert.Nil(t, storage.get(v2))
 
-	storage.Rollback(0)
-	t.Log("v1", storage.Get(v1), "v2", storage.Get(v2))
-	assert.Nil(t, storage.Get(v1))
-	assert.Nil(t, storage.Get(v2))
+	storage.rollback(0)
+	t.Log("v1", storage.get(v1), "v2", storage.get(v2))
+	assert.Nil(t, storage.get(v1))
+	assert.Nil(t, storage.get(v2))
 }
 
 func TestStorageDelete(t *testing.T) {
-	storage := NewBufferedStorage(nil, nil)
+	storage := newBufferedStorage(nil, nil)
 	v1 := types.GetHashID([]byte("v1"))
 	v2 := types.GetHashID([]byte("v2"))
 
-	storage.Put(NewValueEntry(v1, []byte{1}))
-	storage.Put(NewValueEntry(v2, []byte{2}))
+	storage.put(newValueEntry(v1, []byte{1}))
+	storage.put(newValueEntry(v2, []byte{2}))
 
-	storage.Checkpoint(0)
-	storage.Put(NewValueEntry(v1, []byte{3}))
-	storage.Put(NewValueEntry(v2, []byte{4}))
-	storage.Put(NewValueEntry(v2, []byte{5}))
+	storage.checkpoint(0)
+	storage.put(newValueEntry(v1, []byte{3}))
+	storage.put(newValueEntry(v2, []byte{4}))
+	storage.put(newValueEntry(v2, []byte{5}))
 
-	storage.Checkpoint(1)
-	storage.Put(NewValueEntry(v1, []byte{6}))
-	storage.Put(NewValueEntry(v2, []byte{7}))
-	storage.Put(NewValueEntryDelete(v2))
-	t.Log("v1", storage.Get(v1).Value(), "v2", storage.Get(v2).Value())
-	assert.Equal(t, []byte{6}, storage.Get(v1).Value())
-	assert.Equal(t, []byte{0}, storage.Get(v2).Hash())
-	assert.Nil(t, storage.Get(v2).Value())
+	storage.checkpoint(1)
+	storage.put(newValueEntry(v1, []byte{6}))
+	storage.put(newValueEntry(v2, []byte{7}))
+	storage.put(newValueEntryDelete(v2))
+	t.Log("v1", storage.get(v1).Value(), "v2", storage.get(v2).Value())
+	assert.Equal(t, []byte{6}, storage.get(v1).Value())
+	assert.Equal(t, []byte{0}, storage.get(v2).Hash())
+	assert.Nil(t, storage.get(v2).Value())
 
-	storage.Rollback(1)
-	t.Log("v1", storage.Get(v1).Value(), "v2", storage.Get(v2).Value())
-	assert.Equal(t, []byte{3}, storage.Get(v1).Value())
-	assert.Equal(t, []byte{5}, storage.Get(v2).Value())
+	storage.rollback(1)
+	t.Log("v1", storage.get(v1).Value(), "v2", storage.get(v2).Value())
+	assert.Equal(t, []byte{3}, storage.get(v1).Value())
+	assert.Equal(t, []byte{5}, storage.get(v2).Value())
 
-	storage.Put(NewValueEntryDelete(v2))
-	t.Log("v1", storage.Get(v1).Value(), "v2", storage.Get(v2).Value())
-	assert.Equal(t, []byte{3}, storage.Get(v1).Value())
-	assert.Equal(t, []byte{0}, storage.Get(v2).Hash())
-	assert.Nil(t, storage.Get(v2).Value())
+	storage.put(newValueEntryDelete(v2))
+	t.Log("v1", storage.get(v1).Value(), "v2", storage.get(v2).Value())
+	assert.Equal(t, []byte{3}, storage.get(v1).Value())
+	assert.Equal(t, []byte{0}, storage.get(v2).Hash())
+	assert.Nil(t, storage.get(v2).Value())
 }
 
 func TestStorageHasKey(t *testing.T) {
-	storage := NewBufferedStorage(nil, nil)
+	storage := newBufferedStorage(nil, nil)
 	v1 := types.GetHashID([]byte("v1"))
 
-	assert.False(t, storage.Has(v1, false)) // check buffer only
-	assert.False(t, storage.Has(v1, true))  // check buffer and trie
+	assert.False(t, storage.has(v1, false)) // check buffer only
+	assert.False(t, storage.has(v1, true))  // check buffer and trie
 
 	// put entry
-	storage.Put(NewValueEntry(v1, []byte{1}))
-	assert.True(t, storage.Has(v1, false)) // buffer has key
-	assert.True(t, storage.Has(v1, true))  // buffer has key
+	storage.put(newValueEntry(v1, []byte{1}))
+	assert.True(t, storage.has(v1, false)) // buffer has key
+	assert.True(t, storage.has(v1, true))  // buffer has key
 
 	// update storage and reset buffer
-	err := storage.Update()
+	err := storage.update()
 	assert.NoError(t, err, "failed to update storage")
-	err = storage.Buffer.Reset()
+	err = storage.Buffer.reset()
 	assert.NoError(t, err, "failed to reset buffer")
 	// after update and reset
-	assert.False(t, storage.Has(v1, false)) // buffer doesn't have key
-	assert.True(t, storage.Has(v1, true))   // buffer doesn't have, but trie has key
+	assert.False(t, storage.has(v1, false)) // buffer doesn't have key
+	assert.True(t, storage.has(v1, true))   // buffer doesn't have, but trie has key
 
 	// delete entry
-	storage.Put(NewValueEntryDelete(v1))
-	assert.True(t, storage.Has(v1, false)) // buffer has key
-	assert.True(t, storage.Has(v1, true))  // buffer has key
+	storage.put(newValueEntryDelete(v1))
+	assert.True(t, storage.has(v1, false)) // buffer has key
+	assert.True(t, storage.has(v1, true))  // buffer has key
 
 	// update storage and reset buffer
-	err = storage.Update()
+	err = storage.update()
 	assert.NoError(t, err, "failed to update storage")
-	err = storage.Buffer.Reset()
+	err = storage.Buffer.reset()
 	assert.NoError(t, err, "failed to reset buffer")
 	// after update and reset
-	assert.False(t, storage.Has(v1, false)) // buffer doesn't have key
-	assert.False(t, storage.Has(v1, true))  // buffer and trie don't have key
+	assert.False(t, storage.has(v1, false)) // buffer doesn't have key
+	assert.False(t, storage.has(v1, true))  // buffer and trie don't have key
 }


### PR DESCRIPTION
## What is changed?

add id field in ContractState ( to identify AccountState in vm )
move ContractState to statedb ( it related with [evm_state_wip](https://github.com/aergoio/aergo/tree/experiment/evm_state_wip) )
change balance modify logic in vm.go to use AccountState (luaSendAmount, luaCallContract, luaDeployContract)
replace add/sub balance logic to state.SendBalance()
fix some tests in vm and governance

## Is there risk of fork?
yes. it need to sync test.