### PR TITLE
Change log message of unidentified http request for investigation

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -261,7 +261,7 @@ func (ns *RPC) grpcWebHandlerFunc(grpcWebServer *grpcweb.WrappedGrpcServer, othe
 		if grpcWebServer.IsAcceptableGrpcCorsRequest(r) || grpcWebServer.IsGrpcWebRequest(r) || grpcWebServer.IsGrpcWebSocketRequest(r) {
 			grpcWebServer.ServeHTTP(w, r)
 		} else {
-			ns.Info().Msg("Request handled by other hanlder. is this correct?")
+			ns.Info().Stringer("url", r.URL).Str("content_type", r.Header.Get("content-type")).Str("remote_addr", r.RemoteAddr).Msg("Request handled by other handler. is this correct?")
 			otherHandler.ServeHTTP(w, r)
 		}
 	})

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -261,7 +261,7 @@ func (ns *RPC) grpcWebHandlerFunc(grpcWebServer *grpcweb.WrappedGrpcServer, othe
 		if grpcWebServer.IsAcceptableGrpcCorsRequest(r) || grpcWebServer.IsGrpcWebRequest(r) || grpcWebServer.IsGrpcWebSocketRequest(r) {
 			grpcWebServer.ServeHTTP(w, r)
 		} else {
-			ns.Info().Stringer("url", r.URL).Str("content_type", r.Header.Get("content-type")).Str("remote_addr", r.RemoteAddr).Msg("Request handled by other handler. is this correct?")
+			ns.Info().Str("proto", r.Proto).Str("host", r.Host).Stringer("uri", r.URL).Str("content_type", r.Header.Get("content-type")).Str("remote_addr", r.RemoteAddr).Msg("Request handled by other handler. is this correct?")
 			otherHandler.ServeHTTP(w, r)
 		}
 	})


### PR DESCRIPTION
As a guess, it seems that originally the prev code was assumed that only grpcweb was supported, so if an http request other than grpc came, it could be an incorrect request or an impure intention, so it recorded logs at INFO level.
However, many other requests are coming in, so there are quite a lot of logs recorded on the testnet nodes, but there is no context in that log messages, so a lot of meaningless messages are piling up.
This commit is not a solution of the problem. The code has been modified to leave more detailed logs for analysis, and a commit that fixes the real problem will be recreated using the logs produced by this commit.