### PR TITLE
save contract source code

### DIFF
--- a/contract/vm.go
+++ b/contract/vm.go
@@ -902,12 +902,15 @@ func setContract(contractState *statedb.ContractState, contractAddress, payload 
 	}
 	code := codePayload.Code()  // type: LuaCode
 
+	var sourceCode []byte
 	var bytecodeABI []byte
+	var err error
+
 	// if hardfork version 4
 	if ctx.blockInfo.ForkVersion >= 4 {
 		// the payload must be lua code. compile it to bytecode
-		var err error
-		bytecodeABI, err = Compile(string(code), nil)
+		sourceCode = code
+		bytecodeABI, err = Compile(string(sourceCode), nil)
 		if err != nil {
 			ctrLgr.Warn().Err(err).Str("contract", types.EncodeAddress(contractAddress)).Msg("deploy")
 			return nil, nil, err
@@ -918,7 +921,7 @@ func setContract(contractState *statedb.ContractState, contractAddress, payload 
 	}
 
 	// save the bytecode to the contract state
-	err := contractState.SetCode(bytecodeABI)
+	err = contractState.SetCode(sourceCode, bytecodeABI)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contract/vm_state.go
+++ b/contract/vm_state.go
@@ -118,7 +118,7 @@ func (re *recoveryEntry) recovery(bs *state.BlockState) error {
 			return newDbSystemError(err)
 		}
 		if re.isDeploy {
-			err := cs.ctrState.SetCode(nil)
+			err := cs.ctrState.SetCode(nil, nil)
 			if err != nil {
 				return newDbSystemError(err)
 			}

--- a/state/account.go
+++ b/state/account.go
@@ -102,7 +102,7 @@ func (as *AccountState) IsNew() bool {
 }
 
 func (as *AccountState) IsContract() bool {
-	return len(as.State().CodeHash) > 0
+	return len(as.State().CodeHash) > 0 || len(as.State().SourceHash) > 0
 }
 
 func (as *AccountState) IsDeploy() bool {

--- a/state/statedb/contract_test.go
+++ b/state/statedb/contract_test.go
@@ -17,7 +17,7 @@ func TestContractStateCode(t *testing.T) {
 	assert.NoError(t, err, "could not open contract state")
 
 	// set code
-	err = contractState.SetCode(testBytes)
+	err = contractState.SetCode(nil, testBytes)
 	assert.NoError(t, err, "set code to contract state")
 
 	// get code

--- a/types/blockchain.pb.go
+++ b/types/blockchain.pb.go
@@ -668,6 +668,7 @@ type State struct {
 	CodeHash         []byte `protobuf:"bytes,3,opt,name=codeHash,proto3" json:"codeHash,omitempty"`
 	StorageRoot      []byte `protobuf:"bytes,4,opt,name=storageRoot,proto3" json:"storageRoot,omitempty"`
 	SqlRecoveryPoint uint64 `protobuf:"varint,5,opt,name=sqlRecoveryPoint,proto3" json:"sqlRecoveryPoint,omitempty"`
+	SourceHash       []byte `protobuf:"bytes,6,opt,name=sourceHash,proto3" json:"sourceHash,omitempty"`
 }
 
 func (x *State) Reset() {
@@ -719,6 +720,13 @@ func (x *State) GetBalance() []byte {
 func (x *State) GetCodeHash() []byte {
 	if x != nil {
 		return x.CodeHash
+	}
+	return nil
+}
+
+func (x *State) GetSourceHash() []byte {
+	if x != nil {
+		return x.SourceHash
 	}
 	return nil
 }


### PR DESCRIPTION
Save the source code of the deployed contract (both via transaction and via `contract.deploy()`) on the contract state, starting on hardfork V4

The previous method for V4 was to just compile the source code from the transaction and store only the bytecode

Now both bytecode and source code would be stored

This can be useful in the future if we want to use a Lua interpreter instead of LuaJIT (for some contracts)