### PR TITLE
internal operations

### DIFF
--- a/chain/chaindb.go
+++ b/chain/chaindb.go
@@ -665,6 +665,11 @@ func (cdb *ChainDB) checkExistReceipts(blockHash []byte, blockNo types.BlockNo) 
 	return true
 }
 
+func (cdb *ChainDB) getInternalOperations(blockNo types.BlockNo) string {
+	data := cdb.store.Get(dbkey.InternalOps(blockNo))
+	return string(data)
+}
+
 type ChainTree struct {
 	Tree []ChainInfo
 }

--- a/chain/chaindb.go
+++ b/chain/chaindb.go
@@ -520,7 +520,7 @@ func (cdb *ChainDB) dropBlock(dropNo types.BlockNo) error {
 	}
 
 	// remove receipt
-	cdb.deleteReceipts(&dbTx, dropBlock.BlockHash(), dropBlock.BlockNo())
+	cdb.deleteReceiptsAndOperations(&dbTx, dropBlock.BlockHash(), dropBlock.BlockNo())
 
 	// remove (hash/block)
 	dbTx.Delete(dropBlock.BlockHash())
@@ -717,8 +717,9 @@ func (cdb *ChainDB) writeReceiptsAndOperations(block *types.Block, receipts *typ
 	dbTx.Commit()
 }
 
-func (cdb *ChainDB) deleteReceipts(dbTx *db.Transaction, blockHash []byte, blockNo types.BlockNo) {
+func (cdb *ChainDB) deleteReceiptsAndOperations(dbTx *db.Transaction, blockHash []byte, blockNo types.BlockNo) {
 	(*dbTx).Delete(dbkey.Receipts(blockHash, blockNo))
+	(*dbTx).Delete(dbkey.InternalOps(blockNo))
 }
 
 func (cdb *ChainDB) writeReorgMarker(marker *ReorgMarker) error {

--- a/chain/chainhandle.go
+++ b/chain/chainhandle.go
@@ -278,6 +278,20 @@ func (cs *ChainService) listEvents(filter *types.FilterInfo) ([]*types.Event, er
 	return events, nil
 }
 
+func (cs *ChainService) getInternalOperations(blockNo types.BlockNo) (string, error) {
+	blockInMainChain, err := cs.cdb.GetBlockByNo(blockNo)
+	if err != nil {
+		return "", &ErrNoBlock{blockNo}
+	}
+
+	block, err := cs.cdb.getBlock(blockInMainChain.BlockHash())
+	if !bytes.Equal(block.BlockHash(), blockInMainChain.BlockHash()) {
+		return "", errors.New("internal operations not found")
+	}
+
+	return cs.cdb.getInternalOperations(blockNo), nil
+}
+
 type chainProcessor struct {
 	*ChainService
 	block       *types.Block // starting block

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -182,6 +182,7 @@ type IChainHandler interface {
 	getReceipt(txHash []byte) (*types.Receipt, error)
 	getReceipts(blockHash []byte) (*types.Receipts, error)
 	getReceiptsByNo(blockNo types.BlockNo) (*types.Receipts, error)
+	getInternalOperations(blockNo types.BlockNo) (string, error)
 	getAccountVote(addr []byte) (*types.AccountVoteInfo, error)
 	getVotes(id string, n uint32) (*types.VoteList, error)
 	getStaking(addr []byte) (*types.Staking, error)
@@ -444,6 +445,7 @@ func (cs *ChainService) Receive(context actor.Context) {
 		*message.GetReceipt,
 		*message.GetReceipts,
 		*message.GetReceiptsByNo,
+		*message.GetInternalOperations,
 		*message.GetABI,
 		*message.GetQuery,
 		*message.GetStateQuery,
@@ -811,6 +813,12 @@ func (cw *ChainWorker) Receive(context actor.Context) {
 		context.Respond(message.GetReceiptsByNoRsp{
 			Receipts: receipts,
 			Err:      err,
+		})
+	case *message.GetInternalOperations:
+		operations, err := cw.getInternalOperations(msg.BlockNo)
+		context.Respond(message.GetInternalOperationsRsp{
+			Operations: operations,
+			Err:        err,
 		})
 	case *message.GetABI:
 		sdb = cw.sdb.OpenNewStateDB(cw.sdb.GetRoot())

--- a/chain/reorg.go
+++ b/chain/reorg.go
@@ -491,7 +491,7 @@ func (reorg *reorganizer) rollback() error {
 func (reorg *reorganizer) deleteOldReceipts() {
 	dbTx := reorg.cs.cdb.NewTx()
 	for _, blk := range reorg.oldBlocks {
-		reorg.cs.cdb.deleteReceipts(&dbTx, blk.GetHash(), blk.BlockNo())
+		reorg.cs.cdb.deleteReceiptsAndOperations(&dbTx, blk.GetHash(), blk.BlockNo())
 	}
 	dbTx.Commit()
 }

--- a/contract/internal_operations.go
+++ b/contract/internal_operations.go
@@ -4,76 +4,143 @@ import (
 	"encoding/json"
 	"log"
 	"sync"
+
+	"github.com/aergoio/aergo/v2/types"
+	"github.com/aergoio/aergo/v2/types/dbkey"
 )
 
 type InternalOperation struct {
 	Id        int64    `json:"-"`
-	Level     int      `json:"level"`
-	Contract  string   `json:"contract"`
-	Operation string   `json:"operation"`
+	Operation string   `json:"op"`
 	Amount    string   `json:"amount"`
 	Args      []string `json:"args"`
-	Results   []string `json:"results"`
+	Result    string   `json:"result"`
+	Call      InternalCall `json:"call"`
 }
 
+type InternalCall struct {
+	Contract  string   `json:"contract"`
+	Function  string   `json:"function"`
+	Args      string   `json:"args"`
+	Amount    string   `json:"amount"`
+	Operations []InternalOperation `json:"operations"`
+}
+
+
 var (
-	internalOperations []InternalOperation
-	txHash             []byte
-	opsLock            sync.Mutex // To handle concurrent updates
-	nextOpId           int64
+	opsLock      sync.Mutex
+	nextOpId     int64
 )
 
-func initInternalOps(newTxHash []byte) {
-	opsLock.Lock()
-	defer opsLock.Unlock()
+func doNotLog(ctx *vmContext) bool {
+	return ctx.isQuery
+}
 
-	internalOperations = nil // Reinitialize the slice for new transaction
-	txHash = newTxHash
-	nextOpId = 1 // Reset nextOpId for each new transaction
+func getCurrentCall(ctx *vmContext) *InternalCall {
+	var depth int32 = 1
+	opCall := &ctx.internalOpsCall
+	for {
+		if opCall == nil {
+			break
+		}
+		if depth == ctx.callDepth {
+			return opCall
+		}
+		opCall = &opCall.Operations[len(opCall.Operations)-1].Call
+		depth++
+	}
+	return nil
 }
 
 func logOperation(ctx *vmContext, amount string, operation string, args ...string) int64 {
+	if doNotLog(ctx) {
+		return 0
+	}
+
 	opsLock.Lock()
 	defer opsLock.Unlock()
 
+	nextOpId++
+	if nextOpId > 1000000000000000000 {
+		nextOpId = 1
+	}
+
 	op := InternalOperation{
 		Id:        nextOpId,
-		Level:     ctx.CallDepth(),
-		Contract:  ctx.Contract,
 		Operation: operation,
 		Amount:    amount,
 		Args:      args,
 	}
-	internalOperations = append(internalOperations, op)
-	nextOpId++
+
+	opCall := getCurrentCall(ctx)
+	if opCall == nil {
+		log.Printf("no call found")
+		return 0
+	}
+	// add the operation to the list
+	opCall.Operations = append(opCall.Operations, op)
+
 	return op.Id
 }
 
-func logOperationResult(operationId int64, results ...string) {
+func logOperationResult(ctx *vmContext, operationId int64, result string) {
+	if doNotLog(ctx) {
+		return
+	}
+
 	opsLock.Lock()
 	defer opsLock.Unlock()
 
-	for i, op := range internalOperations {
-		if op.Id == operationId {
-			internalOperations[i].Results = append(internalOperations[i].Results, results...)
+	opCall := getCurrentCall(ctx)
+
+	for i := range opCall.Operations {
+		if opCall.Operations[i].Id == operationId {
+			opCall.Operations[i].Result = result
 			return
 		}
 	}
+
 	log.Printf("No operation found with ID %d", operationId)
 }
 
-func saveOperations() {
+func logInternalCall(ctx *vmContext, contract string, function string, args string) error {
+	if doNotLog(ctx) {
+		return nil
+	}
+
+	opCall := getCurrentCall(ctx)
+
+	// get the last operation
+	op := &opCall.Operations[len(opCall.Operations)-1]
+
+	// add this call to the last operation
+	op.Call = InternalCall{
+		Contract: contract,
+		Function: function,
+		Args: args,
+	}
+
+	return nil
+}
+
+func saveOperations(ctx *vmContext) {
+	if doNotLog(ctx) {
+		return
+	}
+
 	opsLock.Lock()
 	defer opsLock.Unlock()
 
-	data, err := json.Marshal(internalOperations)
+	ctx.internalOpsCall.Contract = types.EncodeAddress(ctx.curContract.contractId)
+	//ctx.internalOpsCall.Function = ctx.Function
+
+	data, err := json.Marshal(ctx.internalOpsCall)
 	if err != nil {
 		log.Fatal("Failed to marshal operations:", err)
 		return
 	}
 
-	// Simulated database set function (adjust as needed for actual database implementation)
-	err = db.Set(txHash, data) // Assuming db.Set exists and works with byte keys and value
+	err = db.Set(dbkey.InternalOps(ctx.txHash), data)
 	if err != nil {
 		log.Fatal("Failed to save operations to database:", err)
 	}

--- a/contract/internal_operations.go
+++ b/contract/internal_operations.go
@@ -1,0 +1,80 @@
+package contract
+
+import (
+	"encoding/json"
+	"log"
+	"sync"
+)
+
+type InternalOperation struct {
+	Id        int64    `json:"-"`
+	Level     int      `json:"level"`
+	Contract  string   `json:"contract"`
+	Operation string   `json:"operation"`
+	Amount    string   `json:"amount"`
+	Args      []string `json:"args"`
+	Results   []string `json:"results"`
+}
+
+var (
+	internalOperations []InternalOperation
+	txHash             []byte
+	opsLock            sync.Mutex // To handle concurrent updates
+	nextOpId           int64
+)
+
+func initInternalOps(newTxHash []byte) {
+	opsLock.Lock()
+	defer opsLock.Unlock()
+
+	internalOperations = nil // Reinitialize the slice for new transaction
+	txHash = newTxHash
+	nextOpId = 1 // Reset nextOpId for each new transaction
+}
+
+func logOperation(ctx *vmContext, amount string, operation string, args ...string) int64 {
+	opsLock.Lock()
+	defer opsLock.Unlock()
+
+	op := InternalOperation{
+		Id:        nextOpId,
+		Level:     ctx.CallDepth(),
+		Contract:  ctx.Contract,
+		Operation: operation,
+		Amount:    amount,
+		Args:      args,
+	}
+	internalOperations = append(internalOperations, op)
+	nextOpId++
+	return op.Id
+}
+
+func logOperationResult(operationId int64, results ...string) {
+	opsLock.Lock()
+	defer opsLock.Unlock()
+
+	for i, op := range internalOperations {
+		if op.Id == operationId {
+			internalOperations[i].Results = append(internalOperations[i].Results, results...)
+			return
+		}
+	}
+	log.Printf("No operation found with ID %d", operationId)
+}
+
+func saveOperations() {
+	opsLock.Lock()
+	defer opsLock.Unlock()
+
+	data, err := json.Marshal(internalOperations)
+	if err != nil {
+		log.Fatal("Failed to marshal operations:", err)
+		return
+	}
+
+	// Simulated database set function (adjust as needed for actual database implementation)
+	err = db.Set(txHash, data) // Assuming db.Set exists and works with byte keys and value
+	if err != nil {
+		log.Fatal("Failed to save operations to database:", err)
+	}
+}

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -102,6 +102,7 @@ type vmContext struct {
 	gasLimit          uint64
 	remainedGas       uint64
 	execCtx           context.Context
+	internalOpsCall   InternalCall
 }
 
 type executor struct {

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -826,7 +826,7 @@ func Call(
 	contractState *statedb.ContractState,
 	payload, contractAddress []byte,
 	ctx *vmContext,
-) (string, []*types.Event, *big.Int, error) {
+) (string, []*types.Event, string, *big.Int, error) {
 
 	var err error
 	var ci types.CallInfo
@@ -851,7 +851,7 @@ func Call(
 		err = fmt.Errorf("not found contract %s", addr)
 	}
 	if err != nil {
-		return "", nil, ctx.usedFee(), err
+		return "", nil, "", ctx.usedFee(), err
 	}
 
 	if ctrLgr.IsDebugEnabled() {
@@ -870,6 +870,8 @@ func Call(
 		vmExecTime := time.Now().Sub(startTime).Microseconds()
 		vmLogger.Trace().Int64("execµs", vmExecTime).Stringer("txHash", types.LogBase58(ce.ctx.txHash)).Msg("tx execute time in vm")
 	}
+
+	internalOps := getInternalOperations(ctx)
 
 	// check if there is an error
 	err = ce.err
@@ -895,14 +897,14 @@ func Call(
 				types.EncodeAddress(contractAddress), types.ToAccountID(contractAddress)))
 		}
 		// return the error
-		return "", ce.getEvents(), ctx.usedFee(), err
+		return "", ce.getEvents(), internalOps, ctx.usedFee(), err
 	}
 
 	// save the state of the contract
 	err = ce.commitCalledContract()
 	if err != nil {
 		ctrLgr.Error().Err(err).Str("contract", types.EncodeAddress(contractAddress)).Msg("commit state")
-		return "", ce.getEvents(), ctx.usedFee(), err
+		return "", ce.getEvents(), internalOps, ctx.usedFee(), err
 	}
 
 	// log the result
@@ -923,7 +925,7 @@ func Call(
 	}
 
 	// return the result
-	return ce.jsonRet, ce.getEvents(), ctx.usedFee(), nil
+	return ce.jsonRet, ce.getEvents(), internalOps, ctx.usedFee(), nil
 }
 
 func setRandomSeed(ctx *vmContext) {
@@ -995,10 +997,10 @@ func Create(
 	contractState *statedb.ContractState,
 	payload, contractAddress []byte,
 	ctx *vmContext,
-) (string, []*types.Event, *big.Int, error) {
+) (string, []*types.Event, string, *big.Int, error) {
 
 	if len(payload) == 0 {
-		return "", nil, ctx.usedFee(), errors.New("contract code is required")
+		return "", nil, "", ctx.usedFee(), errors.New("contract code is required")
 	}
 
 	if ctrLgr.IsDebugEnabled() {
@@ -1008,13 +1010,13 @@ func Create(
 	// save the contract code
 	bytecode, args, err := setContract(contractState, contractAddress, payload, ctx)
 	if err != nil {
-		return "", nil, ctx.usedFee(), err
+		return "", nil, "", ctx.usedFee(), err
 	}
 
 	// set the creator
 	err = contractState.SetData(dbkey.CreatorMeta(), []byte(types.EncodeAddress(ctx.curContract.sender)))
 	if err != nil {
-		return "", nil, ctx.usedFee(), err
+		return "", nil, "", ctx.usedFee(), err
 	}
 
 	// get the arguments for the constructor
@@ -1023,7 +1025,7 @@ func Create(
 		err = getCallInfo(&ci.Args, args, contractAddress)
 		if err != nil {
 			errMsg, _ := json.Marshal("constructor call error:" + err.Error())
-			return string(errMsg), nil, ctx.usedFee(), nil
+			return string(errMsg), nil, "", ctx.usedFee(), nil
 		}
 	}
 
@@ -1032,7 +1034,7 @@ func Create(
 	if ctx.blockInfo.ForkVersion < 2 {
 		// create a sql database for the contract
 		if db := luaGetDbHandle(ctx.service); db == nil {
-			return "", nil, ctx.usedFee(), newVmError(errors.New("can't open a database connection"))
+			return "", nil, "", ctx.usedFee(), newVmError(errors.New("can't open a database connection"))
 		}
 	}
 
@@ -1044,6 +1046,8 @@ func Create(
 		// call the constructor
 		ce.call(callMaxInstLimit, nil)
 	}
+
+	internalOps := getInternalOperations(ctx)
 
 	// check if the call failed
 	err = ce.err
@@ -1070,7 +1074,7 @@ func Create(
 				types.EncodeAddress(contractAddress), types.ToAccountID(contractAddress)))
 		}
 		// return the error
-		return "", ce.getEvents(), ctx.usedFee(), err
+		return "", ce.getEvents(), internalOps, ctx.usedFee(), err
 	}
 
 	// commit the state
@@ -1078,7 +1082,7 @@ func Create(
 	if err != nil {
 		ctrLgr.Debug().Msg("constructor is failed")
 		ctrLgr.Error().Err(err).Msg("commit state")
-		return "", ce.getEvents(), ctx.usedFee(), err
+		return "", ce.getEvents(), internalOps, ctx.usedFee(), err
 	}
 
 	// write the trace
@@ -1099,7 +1103,7 @@ func Create(
 	}
 
 	// return the result
-	return ce.jsonRet, ce.getEvents(), ctx.usedFee(), nil
+	return ce.jsonRet, ce.getEvents(), internalOps, ctx.usedFee(), nil
 }
 
 func allocContextSlot(ctx *vmContext) {

--- a/contract/vm_dummy/vm_dummy.go
+++ b/contract/vm_dummy/vm_dummy.go
@@ -485,7 +485,7 @@ func (l *luaTxDeploy) Constructor(args string) *luaTxDeploy {
 }
 
 func contractFrame(l luaTxContract, bs *state.BlockState, cdb contract.ChainAccessor, receiptTx db.Transaction,
-	run func(s, c *state.AccountState, id types.AccountID, cs *statedb.ContractState) (string, []*types.Event, *big.Int, error)) error {
+	run func(s, c *state.AccountState, id types.AccountID, cs *statedb.ContractState) (string, []*types.Event, string, *big.Int, error)) error {
 
 	creatorId := types.ToAccountID(l.sender())
 	creatorState, err := state.GetAccountState(l.sender(), bs.StateDB)
@@ -539,7 +539,7 @@ func contractFrame(l luaTxContract, bs *state.BlockState, cdb contract.ChainAcce
 		return err
 	}
 
-	rv, events, cFee, err := run(creatorState, contractState, contractId, eContractState)
+	rv, events, _, cFee, err := run(creatorState, contractState, contractId, eContractState)
 
 	if cFee != nil {
 		usedFee.Add(usedFee, cFee)
@@ -600,20 +600,20 @@ func (l *luaTxDeploy) run(execCtx context.Context, bs *state.BlockState, bc *Dum
 		l._payload = util.NewLuaCodePayload(byteCode, payload.Args())
 	}
 	return contractFrame(l, bs, bc, receiptTx,
-		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *statedb.ContractState) (string, []*types.Event, *big.Int, error) {
+		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *statedb.ContractState) (string, []*types.Event, string, *big.Int, error) {
 			contractV.State().SqlRecoveryPoint = 1
 
 			ctx := contract.NewVmContext(execCtx, bs, nil, sender, contractV, eContractState, sender.ID(), l.Hash(), bi, "", true, false, contractV.State().SqlRecoveryPoint, contract.BlockFactory, l.amount(), math.MaxUint64, false, false)
 
-			rv, events, ctrFee, err := contract.Create(eContractState, l.payload(), l.recipient(), ctx)
+			rv, events, internalOps, ctrFee, err := contract.Create(eContractState, l.payload(), l.recipient(), ctx)
 			if err != nil {
-				return "", nil, ctrFee, err
+				return "", nil, internalOps, ctrFee, err
 			}
 			err = statedb.StageContractState(eContractState, bs.StateDB)
 			if err != nil {
-				return "", nil, ctrFee, err
+				return "", nil, internalOps, ctrFee, err
 			}
-			return rv, events, ctrFee, nil
+			return rv, events, internalOps, ctrFee, nil
 		},
 	)
 }
@@ -674,23 +674,23 @@ func (l *luaTxCall) Fail(expectedErr string) *luaTxCall {
 
 func (l *luaTxCall) run(execCtx context.Context, bs *state.BlockState, bc *DummyChain, bi *types.BlockHeaderInfo, receiptTx db.Transaction) error {
 	err := contractFrame(l, bs, bc, receiptTx,
-		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *statedb.ContractState) (string, []*types.Event, *big.Int, error) {
+		func(sender, contractV *state.AccountState, contractId types.AccountID, eContractState *statedb.ContractState) (string, []*types.Event, string, *big.Int, error) {
 
 			ctx := contract.NewVmContext(execCtx, bs, bc, sender, contractV, eContractState, sender.ID(), l.Hash(), bi, "", true, false, contractV.State().SqlRecoveryPoint, contract.BlockFactory, l.amount(), math.MaxUint64, l.feeDelegate, l.multiCall)
 
-			rv, events, ctrFee, err := contract.Call(eContractState, l.payload(), l.recipient(), ctx)
+			rv, events, internalOps, ctrFee, err := contract.Call(eContractState, l.payload(), l.recipient(), ctx)
 			if err != nil {
-				return "", nil, ctrFee, err
+				return "", nil, internalOps, ctrFee, err
 			}
 
 			if !ctx.IsMultiCall() {
 				err = statedb.StageContractState(eContractState, bs.StateDB)
 				if err != nil {
-					return "", nil, ctrFee, err
+					return "", nil, internalOps, ctrFee, err
 				}
 			}
 
-			return rv, events, ctrFee, nil
+			return rv, events, internalOps, ctrFee, nil
 		},
 	)
 	if l.expectedErr != "" {

--- a/rpc/grpcserver.go
+++ b/rpc/grpcserver.go
@@ -1067,6 +1067,22 @@ func (rpc *AergoRPCService) GetReceipt(ctx context.Context, in *types.SingleByte
 	return rsp.Receipt, rsp.Err
 }
 
+func (rpc *AergoRPCService) GetInternalOperations(ctx context.Context, in *types.BlockNo) (*types.SingleBytes, error) {
+	if err := rpc.checkAuth(ctx, ReadBlockChain); err != nil {
+		return nil, err
+	}
+	result, err := rpc.hub.RequestFuture(message.ChainSvc,
+		&message.GetInternalOperations{BlockNo: *in}, defaultActorTimeout, "rpc.(*AergoRPCService).GetInternalOperations").Result()
+	if err != nil {
+		return nil, err
+	}
+	rsp, ok := result.(message.GetInternalOperationsRsp)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "internal type (%v) error", reflect.TypeOf(result))
+	}
+	return &types.SingleBytes{Value: []byte(rsp.Operations)}, rsp.Err
+}
+
 func (rpc *AergoRPCService) GetABI(ctx context.Context, in *types.SingleBytes) (*types.ABI, error) {
 	if err := rpc.checkAuth(ctx, ReadBlockChain); err != nil {
 		return nil, err

--- a/state/block.go
+++ b/state/block.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"strings"
 	"math/big"
 
 	"github.com/aergoio/aergo/v2/consensus"
@@ -15,6 +16,7 @@ type BlockState struct {
 	*statedb.StateDB
 	BpReward      big.Int // final bp reward, increment when tx executes
 	receipts      types.Receipts
+	internalOps   []string
 	CCProposal    *consensus.ConfChangePropose
 	prevBlockHash []byte
 	consensus     []byte // Consensus Header
@@ -78,6 +80,17 @@ func (bs *BlockState) Consensus() []byte {
 
 func (bs *BlockState) SetConsensus(ch []byte) {
 	bs.consensus = ch
+}
+
+func (bs *BlockState) AddInternalOps(txops string) {
+	bs.internalOps = append(bs.internalOps, txops)
+}
+
+func (bs *BlockState) InternalOps() string {
+	if bs == nil || len(bs.internalOps) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(bs.internalOps, ",") + "]"
 }
 
 func (bs *BlockState) AddReceipt(r *types.Receipt) error {

--- a/types/dbkey/key.go
+++ b/types/dbkey/key.go
@@ -25,8 +25,8 @@ func Receipts(blockHash []byte, blockNo types.BlockNo) []byte {
 	return key
 }
 
-func InternalOps(txHash []byte) []byte {
-	return append([]byte(internalOpsPrefix), txHash...)
+func InternalOps(blockNo types.BlockNo) []byte {
+	return append([]byte(internalOpsPrefix), types.BlockNoToBytes(blockNo)...)
 }
 
 //---------------------------------------------------------------------------------//

--- a/types/dbkey/key.go
+++ b/types/dbkey/key.go
@@ -25,6 +25,10 @@ func Receipts(blockHash []byte, blockNo types.BlockNo) []byte {
 	return key
 }
 
+func InternalOps(txHash []byte) []byte {
+	return append([]byte(internalOpsPrefix), txHash...)
+}
+
 //---------------------------------------------------------------------------------//
 // metadata
 

--- a/types/dbkey/schema.go
+++ b/types/dbkey/schema.go
@@ -9,6 +9,7 @@ const (
 // chain
 const (
 	receiptsPrefix = "r"
+	internalOpsPrefix = "i"
 )
 
 // metadata

--- a/types/message/blockchainmsg.go
+++ b/types/message/blockchainmsg.go
@@ -93,6 +93,14 @@ type GetReceiptsByNo struct {
 }
 type GetReceiptsByNoRsp GetReceiptsRsp
 
+type GetInternalOperations struct {
+	BlockNo types.BlockNo
+}
+type GetInternalOperationsRsp struct {
+	Operations string
+	Err        error
+}
+
 type GetABI struct {
 	Contract []byte
 }


### PR DESCRIPTION
* Records the internal operations in the node database
* Encode them as JSON string, all transactions from a block (store just once per block to reduce I/O, using the block number as key)
* Adds a RPC endpoint to retrieve these values