### PR TITLE
Use a more direct and less error-prone return value

### DIFF
--- a/account/key/crypto/v1strategy.go
+++ b/account/key/crypto/v1strategy.go
@@ -255,5 +255,5 @@ func aesCTRXOR(key, inText, iv []byte) ([]byte, error) {
 	stream := cipher.NewCTR(aesBlock, iv)
 	outText := make([]byte, len(inText))
 	stream.XORKeyStream(outText, inText)
-	return outText, err
+	return outText, nil
 }


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.