### PR TITLE
Fix typos in comments across multiple files

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -147,7 +147,7 @@ type RaftConfig struct {
 	BlockFactoryTickMs int64         `mapstructure:"blockfactorytickms" description:"interval to check if block factory should run new task(millisec)"`
 	BlockIntervalMs    int64         `mapstructure:"blockintervalms" description:"block interval for raft (millisec). It overrides BlockInterval of consensus"`
 	NewCluster         bool          `mapstructure:"newcluster" description:"create a new raft cluster if it doesn't already exist"`
-	UseBackup          bool          `mapstructure:"usebackup" description:"use backup datafiles when creating a new cluster or joining to a existing cluster"`
+	UseBackup          bool          `mapstructure:"usebackup" description:"use backup datafiles when creating a new cluster or joining to an existing cluster"`
 	SnapFrequency      uint64        `mapstructure:"snapfrequency" description:"frequency which raft make snapshot with log"`
 	SlowNodeGap        uint          `mapstructure:"slownodegap" description:"frequency which raft make snapshot with log"`
 	RecoverBP          *RaftBPConfig `mapstructure:"recoverbp" description:"bp info for creating a new cluster from backup"`

--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -35,7 +35,7 @@ func (e ErrTimeout) Error() string {
 	return e.Kind + " timeout"
 }
 
-// ErrBlockConnect indicates a error indicating a failed block connected
+// ErrBlockConnect indicates an error indicating a failed block connected
 // request.
 type ErrBlockConnect struct {
 	id     string

--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -35,7 +35,7 @@ func (e ErrTimeout) Error() string {
 	return e.Kind + " timeout"
 }
 
-// ErrBlockConnect indicates an error indicating a failed block connected
+// ErrBlockConnect represents an error indicating a failed block connected
 // request.
 type ErrBlockConnect struct {
 	id     string

--- a/p2p/p2pcommon/others.go
+++ b/p2p/p2pcommon/others.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aergoio/aergo/v2/types"
 )
 
-// PeerAccessor is an interface for an another actor module to get info of peers
+// PeerAccessor is an interface for another actor module to get info of peers
 type PeerAccessor interface {
 	// SelfMeta returns peerid, ipaddress and port of server itself
 	SelfMeta() PeerMeta

--- a/p2p/p2pcommon/others.go
+++ b/p2p/p2pcommon/others.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aergoio/aergo/v2/types"
 )
 
-// PeerAccessor is an interface for a another actor module to get info of peers
+// PeerAccessor is an interface for an another actor module to get info of peers
 type PeerAccessor interface {
 	// SelfMeta returns peerid, ipaddress and port of server itself
 	SelfMeta() PeerMeta

--- a/pkg/component/messages.go
+++ b/pkg/component/messages.go
@@ -16,7 +16,7 @@ type CompStatReq struct {
 
 // CompStatRsp contains component's internal info, used to help debugging
 // - Status is a string representation of a component's status
-// - AccProcessedMsg is an accumulated number of message that this component processes
+// - AccProcessedMsg is the accumulated number of message that this component processes
 // - MsgQueueLen is a current number of message at this component's mailbox
 // - MsgProcessLatency is an estimated latency to process a msg
 // - Error is an error msg when a requester fails to get statics

--- a/pkg/component/messages.go
+++ b/pkg/component/messages.go
@@ -17,7 +17,7 @@ type CompStatReq struct {
 // CompStatRsp contains component's internal info, used to help debugging
 // - Status is a string representation of a component's status
 // - AccProcessedMsg is the accumulated number of message that this component processes
-// - MsgQueueLen is a current number of message at this component's mailbox
+// - MsgQueueLen is the current number of message at this component's mailbox
 // - MsgProcessLatency is an estimated latency to process a msg
 // - Error is an error msg when a requester fails to get statics
 // - Actor is a reserved field to get component's internal debug info

--- a/pkg/component/messages.go
+++ b/pkg/component/messages.go
@@ -17,7 +17,7 @@ type CompStatReq struct {
 // CompStatRsp contains component's internal info, used to help debugging
 // - Status is a string representation of a component's status
 // - AccProcessedMsg is an accumulated number of message that this component processes
-// - MsgQueueLen is an current number of message at this component's mailbox
+// - MsgQueueLen is a current number of message at this component's mailbox
 // - MsgProcessLatency is an estimated latency to process a msg
 // - Error is an error msg when a requester fails to get statics
 // - Actor is a reserved field to get component's internal debug info

--- a/types/blockchain.go
+++ b/types/blockchain.go
@@ -126,7 +126,7 @@ const (
   }
 */
 
-// ChainAccessor is an interface for an another actor module to get info of chain
+// ChainAccessor is an interface for another actor module to get info of chain
 type ChainAccessor interface {
 	GetGenesisInfo() *Genesis
 	GetConsensusInfo() string

--- a/types/blockchain.go
+++ b/types/blockchain.go
@@ -126,7 +126,7 @@ const (
   }
 */
 
-// ChainAccessor is an interface for a another actor module to get info of chain
+// ChainAccessor is an interface for an another actor module to get info of chain
 type ChainAccessor interface {
 	GetGenesisInfo() *Genesis
 	GetConsensusInfo() string

--- a/types/vote.go
+++ b/types/vote.go
@@ -88,7 +88,7 @@ func GetOpSysTx(vName string) OpSysTx {
 	return cmdToOp[vName]
 }
 
-// Name returns a unprefixed name corresponding to op.
+// Name returns an unprefixed name corresponding to op.
 func (op OpSysTx) ID() string {
 	const prefixLen = 2 // prefix = "Op"
 

--- a/types/vote.go
+++ b/types/vote.go
@@ -57,7 +57,7 @@ const (
 	OpvoteDAO
 	// Opstake represents a staking transaction.
 	Opstake
-	// Opunstake represents an unstaking transaction.
+	// Opunstake represents the unstaking transaction.
 	Opunstake
 	// OpSysTxMax is the maximum of system tx OP numbers.
 	OpSysTxMax
@@ -88,7 +88,7 @@ func GetOpSysTx(vName string) OpSysTx {
 	return cmdToOp[vName]
 }
 
-// Name returns an unprefixed name corresponding to op.
+// Name returns the unprefixed name corresponding to op.
 func (op OpSysTx) ID() string {
 	const prefixLen = 2 // prefix = "Op"
 

--- a/types/vote.go
+++ b/types/vote.go
@@ -57,7 +57,7 @@ const (
 	OpvoteDAO
 	// Opstake represents a staking tranaction.
 	Opstake
-	// Opunstake represents a unstaking tranaction.
+	// Opunstake represents an unstaking tranaction.
 	Opunstake
 	// OpSysTxMax is the maximum of system tx OP numbers.
 	OpSysTxMax

--- a/types/vote.go
+++ b/types/vote.go
@@ -55,9 +55,9 @@ const (
 	OpvoteBP OpSysTx = iota
 	// OpvoteDAO corresponds to a proposal transaction for a system parameter change.
 	OpvoteDAO
-	// Opstake represents a staking tranaction.
+	// Opstake represents a staking transaction.
 	Opstake
-	// Opunstake represents an unstaking tranaction.
+	// Opunstake represents an unstaking transaction.
 	Opunstake
 	// OpSysTxMax is the maximum of system tx OP numbers.
 	OpSysTxMax


### PR DESCRIPTION
This PR corrects several minor typos in comments across various files, improving the clarity and professionalism of the code documentation.

---

### Files Updated  
1. **config/types.go**  
   - Corrected "joining to a existing cluster" to "joining to an existing cluster."

2. **consensus/chain/block.go**  
   - Fixed "a error" to "an error."

3. **p2p/p2pcommon/others.go**  
   - Updated "an another actor module" to "another actor module."

4. **pkg/component/messages.go**  
   - Changed "an current number of message" to "a current number of message."

5. **types/blockchain.go**  
   - Corrected "an another actor module" to "another actor module."

6. **types/vote.go**  
   - Fixed "a unstaking tranaction" to "an unstaking tranaction."  
   - Changed "a unprefixed name" to "an unprefixed name."