### PR TITLE
deploy: add support for import statement on aergocli and brick

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # @copyright defined in aergo/LICENSE.txt
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(aergo NONE)
 

--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -9,6 +9,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"bufio"
+	"strings"
+	"path/filepath"
+	"io/ioutil"
+	"net/http"
 
 	luacEncoding "github.com/aergoio/aergo/v2/cmd/aergoluac/encoding"
 	luac "github.com/aergoio/aergo/v2/cmd/aergoluac/util"
@@ -180,7 +185,7 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = false
 			return errors.New("not enough arguments")
 		}
-		code, err = os.ReadFile(args[1])
+		code, err = readContract(args[1])
 		if err != nil {
 			return fmt.Errorf("failed to read code file: %v", err.Error())
 		}
@@ -496,4 +501,130 @@ func fillChainId(tx *types.Tx) string {
 	}
 	tx.Body.ChainIdHash = msg.GetBestChainIdHash()
 	return ""
+}
+
+// Set to track imported files
+var importedFiles = make(map[string]bool)
+
+// ProcessLines processes a string containing contract code, handling imports
+func processLines(input string) (string, error) {
+
+	// Create a string builder for the output
+	var output strings.Builder
+
+	// Process each line
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if line starts with "import "
+		if strings.HasPrefix(line, "import ") {
+			// Extract the file name from import statement
+			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
+
+			// Check if it has minimum length for a valid import
+			if len(importLine) < 3 {
+				return "", fmt.Errorf("invalid import format: %s", line)
+			}
+
+			// Check if it starts with a valid quote character
+			quoteChar := importLine[0]
+			if quoteChar != '"' && quoteChar != '\'' {
+				return "", fmt.Errorf("import statement must use quotes: %s", line)
+			}
+
+			// Check if it ends with the same quote character
+			if importLine[len(importLine)-1] != quoteChar {
+				return "", fmt.Errorf("mismatched quotes in import: %s", line)
+			}
+
+			// Extract the file path between quotes
+			importFile := importLine[1 : len(importLine)-1]
+
+			// Get absolute path to check for circular imports
+			absImportPath, err := filepath.Abs(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error getting absolute path: %w", err)
+			}
+
+			// Skip if already imported
+			if importedFiles[absImportPath] {
+				continue
+			}
+
+			// Mark as imported
+			importedFiles[absImportPath] = true
+
+			// Read the imported file
+			importContent, err := readContractFile(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
+			}
+
+			// Process the imported content recursively
+			processedImport, err := processLines(importContent)
+			if err != nil {
+				return "", err
+			}
+
+			// Add the processed import to output
+			output.WriteString(processedImport)
+			output.WriteString("\n")
+		} else {
+			// Regular line, add to output
+			output.WriteString(line)
+			output.WriteString("\n")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error scanning input: %w", err)
+	}
+
+	return output.String(), nil
+}
+
+func readContractFile(filePath string) (string, error) {
+	// if the file path is a url, read it from the web
+	if strings.HasPrefix(filePath, "http") {
+		// search in the web
+		req, err := http.NewRequest("GET", filePath, nil)
+		if err != nil {
+			return "", err
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		fileBytes, _ := ioutil.ReadAll(resp.Body)
+		return string(fileBytes), nil
+	}
+
+	// search in the local file system
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return "", err
+	}
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(fileBytes), nil
+}
+
+func readContract(filePath string) ([]byte, error) {
+	// Reset imported files tracking for each new processing
+	importedFiles = make(map[string]bool)
+	// read the contract file
+	output, err := readContractFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	// process the contract file for import statements
+	output, err = processLines(output)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(output), nil
 }

--- a/cmd/aergocli/cmd/contract.go
+++ b/cmd/aergocli/cmd/contract.go
@@ -7,16 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
-	"bufio"
-	"strings"
-	"path/filepath"
-	"io/ioutil"
-	"net/http"
 
 	luacEncoding "github.com/aergoio/aergo/v2/cmd/aergoluac/encoding"
 	luac "github.com/aergoio/aergo/v2/cmd/aergoluac/util"
+	"github.com/aergoio/aergo/v2/cmd/brick/pack"
 	"github.com/aergoio/aergo/v2/internal/common"
 	"github.com/aergoio/aergo/v2/internal/enc/base58"
 	"github.com/aergoio/aergo/v2/internal/enc/hex"
@@ -185,10 +180,11 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = false
 			return errors.New("not enough arguments")
 		}
-		code, err = readContract(args[1])
+		codeString, err := pack.ReadContract(args[1])
 		if err != nil {
 			return fmt.Errorf("failed to read code file: %v", err.Error())
 		}
+		code = []byte(codeString)
 		if len(args) == 3 {
 			var ci types.CallInfo
 			err = json.Unmarshal([]byte(args[2]), &ci.Args)
@@ -501,130 +497,4 @@ func fillChainId(tx *types.Tx) string {
 	}
 	tx.Body.ChainIdHash = msg.GetBestChainIdHash()
 	return ""
-}
-
-// Set to track imported files
-var importedFiles = make(map[string]bool)
-
-// ProcessLines processes a string containing contract code, handling imports
-func processLines(input string) (string, error) {
-
-	// Create a string builder for the output
-	var output strings.Builder
-
-	// Process each line
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Check if line starts with "import "
-		if strings.HasPrefix(line, "import ") {
-			// Extract the file name from import statement
-			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
-
-			// Check if it has minimum length for a valid import
-			if len(importLine) < 3 {
-				return "", fmt.Errorf("invalid import format: %s", line)
-			}
-
-			// Check if it starts with a valid quote character
-			quoteChar := importLine[0]
-			if quoteChar != '"' && quoteChar != '\'' {
-				return "", fmt.Errorf("import statement must use quotes: %s", line)
-			}
-
-			// Check if it ends with the same quote character
-			if importLine[len(importLine)-1] != quoteChar {
-				return "", fmt.Errorf("mismatched quotes in import: %s", line)
-			}
-
-			// Extract the file path between quotes
-			importFile := importLine[1 : len(importLine)-1]
-
-			// Get absolute path to check for circular imports
-			absImportPath, err := filepath.Abs(importFile)
-			if err != nil {
-				return "", fmt.Errorf("error getting absolute path: %w", err)
-			}
-
-			// Skip if already imported
-			if importedFiles[absImportPath] {
-				continue
-			}
-
-			// Mark as imported
-			importedFiles[absImportPath] = true
-
-			// Read the imported file
-			importContent, err := readContractFile(importFile)
-			if err != nil {
-				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
-			}
-
-			// Process the imported content recursively
-			processedImport, err := processLines(importContent)
-			if err != nil {
-				return "", err
-			}
-
-			// Add the processed import to output
-			output.WriteString(processedImport)
-			output.WriteString("\n")
-		} else {
-			// Regular line, add to output
-			output.WriteString(line)
-			output.WriteString("\n")
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error scanning input: %w", err)
-	}
-
-	return output.String(), nil
-}
-
-func readContractFile(filePath string) (string, error) {
-	// if the file path is a url, read it from the web
-	if strings.HasPrefix(filePath, "http") {
-		// search in the web
-		req, err := http.NewRequest("GET", filePath, nil)
-		if err != nil {
-			return "", err
-		}
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-		fileBytes, _ := ioutil.ReadAll(resp.Body)
-		return string(fileBytes), nil
-	}
-
-	// search in the local file system
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return "", err
-	}
-	fileBytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return "", err
-	}
-	return string(fileBytes), nil
-}
-
-func readContract(filePath string) ([]byte, error) {
-	// Reset imported files tracking for each new processing
-	importedFiles = make(map[string]bool)
-	// read the contract file
-	output, err := readContractFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-	// process the contract file for import statements
-	output, err = processLines(output)
-	if err != nil {
-		return nil, err
-	}
-	return []byte(output), nil
 }

--- a/cmd/brick/brick.go
+++ b/cmd/brick/brick.go
@@ -85,6 +85,7 @@ func main() {
 		fmt.Fprintln(flag.CommandLine.Output(), "Usage:")
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s [-p]\n", os.Args[0])
 		fmt.Fprintf(flag.CommandLine.Output(), "  %s [-p] [-V] [-w] <filename>\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s [-p] pack <input_file> [<output_file>]\n", os.Args[0])
 		flag.PrintDefaults()
 	}
 	verbose := flag.Bool("V", false, "verbose output (only batch)")
@@ -111,6 +112,25 @@ func main() {
 			prompt.OptionTitle("Aergo Brick: Dummy Virtual Machine"),
 		)
 		p.Run()
+	} else if flag.Arg(0) == "pack" {
+		// pack command
+		if flag.NArg() < 2 {
+			fmt.Fprintln(os.Stderr, "Error: pack command requires an input file")
+			exitCode = 1
+			return
+		}
+
+		inputFile := flag.Arg(1)
+		outputFile := ""
+		if flag.NArg() > 2 {
+			outputFile = flag.Arg(2)
+		} else {
+			// replace the last .lua with -bundle.lua
+			outputFile = strings.TrimSuffix(inputFile, ".lua") + "-bundle.lua"
+		}
+
+		// Call the pack function with the input and output files
+		exitCode = exec.ExecutePack(inputFile, outputFile)
 	} else {
 		// call batch executor
 		cmd := "batch"

--- a/cmd/brick/exec/deployContract.go
+++ b/cmd/brick/exec/deployContract.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -49,35 +50,126 @@ func (c *deployContract) Validate(args string) error {
 	return err
 }
 
-func (c *deployContract) readDefFile(defPath string) ([]byte, error) {
-	if strings.HasPrefix(defPath, "http") {
+// Set to track imported files
+var importedFiles = make(map[string]bool)
+
+// ProcessLines processes a string containing contract code, handling imports
+func (c *deployContract) processLines(input string) (string, error) {
+
+	// Create a string builder for the output
+	var output strings.Builder
+
+	// Process each line
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if line starts with "import "
+		if strings.HasPrefix(line, "import ") {
+			// Extract the file name from import statement
+			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
+
+			// Check if it has minimum length for a valid import
+			if len(importLine) < 3 {
+				return "", fmt.Errorf("invalid import format: %s", line)
+			}
+
+			// Check if it starts with a valid quote character
+			quoteChar := importLine[0]
+			if quoteChar != '"' && quoteChar != '\'' {
+				return "", fmt.Errorf("import statement must use quotes: %s", line)
+			}
+
+			// Check if it ends with the same quote character
+			if importLine[len(importLine)-1] != quoteChar {
+				return "", fmt.Errorf("mismatched quotes in import: %s", line)
+			}
+
+			// Extract the file path between quotes
+			importFile := importLine[1 : len(importLine)-1]
+
+			// Get absolute path to check for circular imports
+			absImportPath, err := filepath.Abs(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error getting absolute path: %w", err)
+			}
+
+			// Skip if already imported
+			if importedFiles[absImportPath] {
+				continue
+			}
+
+			// Mark as imported
+			importedFiles[absImportPath] = true
+
+			// Read the imported file
+			importContent, err := c.readContractFile(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
+			}
+
+			// Process the imported content recursively
+			processedImport, err := c.processLines(importContent)
+			if err != nil {
+				return "", err
+			}
+
+			// Add the processed import to output
+			output.WriteString(processedImport)
+			output.WriteString("\n")
+		} else {
+			// Regular line, add to output
+			output.WriteString(line)
+			output.WriteString("\n")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error scanning input: %w", err)
+	}
+
+	return output.String(), nil
+}
+
+func (c *deployContract) readContractFile(filePath string) (string, error) {
+	// if the file path is a url, read it from the web
+	if strings.HasPrefix(filePath, "http") {
 		// search in the web
-		req, err := http.NewRequest("GET", defPath, nil)
+		req, err := http.NewRequest("GET", filePath, nil)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		defer resp.Body.Close()
-		defByte, _ := ioutil.ReadAll(resp.Body)
-
-		return defByte, nil
+		fileBytes, _ := ioutil.ReadAll(resp.Body)
+		return string(fileBytes), nil
 	}
 
-	// search in a local file system
-	if _, err := os.Stat(defPath); os.IsNotExist(err) {
-		return nil, err
+	// search in the local file system
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return "", err
 	}
-	defByte, err := ioutil.ReadFile(defPath)
+	fileBytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
+	return string(fileBytes), nil
+}
 
-	return defByte, nil
-
+func (c *deployContract) readContract(filePath string) (string, error) {
+	// Reset imported files tracking for each new processing
+	importedFiles = make(map[string]bool)
+	// read the contract file
+	output, err := c.readContractFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	// process the contract file for import statements
+	return c.processLines(output)
 }
 
 func (c *deployContract) parse(args string) (string, *big.Int, string, string, string, error) {
@@ -93,7 +185,7 @@ func (c *deployContract) parse(args string) (string, *big.Int, string, string, s
 	}
 
 	defPath := splitArgs[3].Text
-	if _, err := c.readDefFile(defPath); err != nil {
+	if _, err := c.readContract(defPath); err != nil {
 		return "", nil, "", "", "", fmt.Errorf("fail to read a contract def file %s: %s", splitArgs[3].Text, err.Error())
 	}
 
@@ -115,7 +207,7 @@ func (c *deployContract) parse(args string) (string, *big.Int, string, string, s
 func (c *deployContract) Run(args string) (string, uint64, []*types.Event, error) {
 	accountName, amount, contractName, defPath, constuctorArg, _ := c.parse(args)
 
-	defByte, err := c.readDefFile(defPath)
+	defByte, err := c.readContract(defPath)
 	if err != nil {
 		return "", 0, nil, err
 	}

--- a/cmd/brick/exec/deployContract.go
+++ b/cmd/brick/exec/deployContract.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aergoio/aergo/v2/cmd/brick/context"
+	"github.com/aergoio/aergo/v2/cmd/brick/pack"
 	"github.com/aergoio/aergo/v2/contract/vm_dummy"
 	"github.com/aergoio/aergo/v2/types"
 )
@@ -59,7 +60,7 @@ func (c *deployContract) parse(args string) (string, *big.Int, string, string, s
 	}
 
 	defPath := splitArgs[3].Text
-	if _, err := readContract(defPath); err != nil {
+	if _, err := pack.ReadContract(defPath); err != nil {
 		return "", nil, "", "", "", fmt.Errorf("fail to read a contract def file %s: %s", splitArgs[3].Text, err.Error())
 	}
 
@@ -81,7 +82,7 @@ func (c *deployContract) parse(args string) (string, *big.Int, string, string, s
 func (c *deployContract) Run(args string) (string, uint64, []*types.Event, error) {
 	accountName, amount, contractName, defPath, constuctorArg, _ := c.parse(args)
 
-	defByte, err := readContract(defPath)
+	defByte, err := pack.ReadContract(defPath)
 	if err != nil {
 		return "", 0, nil, err
 	}

--- a/cmd/brick/exec/deployContract.go
+++ b/cmd/brick/exec/deployContract.go
@@ -1,12 +1,8 @@
 package exec
 
 import (
-	"bufio"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -50,128 +46,6 @@ func (c *deployContract) Validate(args string) error {
 	return err
 }
 
-// Set to track imported files
-var importedFiles = make(map[string]bool)
-
-// ProcessLines processes a string containing contract code, handling imports
-func (c *deployContract) processLines(input string) (string, error) {
-
-	// Create a string builder for the output
-	var output strings.Builder
-
-	// Process each line
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Check if line starts with "import "
-		if strings.HasPrefix(line, "import ") {
-			// Extract the file name from import statement
-			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
-
-			// Check if it has minimum length for a valid import
-			if len(importLine) < 3 {
-				return "", fmt.Errorf("invalid import format: %s", line)
-			}
-
-			// Check if it starts with a valid quote character
-			quoteChar := importLine[0]
-			if quoteChar != '"' && quoteChar != '\'' {
-				return "", fmt.Errorf("import statement must use quotes: %s", line)
-			}
-
-			// Check if it ends with the same quote character
-			if importLine[len(importLine)-1] != quoteChar {
-				return "", fmt.Errorf("mismatched quotes in import: %s", line)
-			}
-
-			// Extract the file path between quotes
-			importFile := importLine[1 : len(importLine)-1]
-
-			// Get absolute path to check for circular imports
-			absImportPath, err := filepath.Abs(importFile)
-			if err != nil {
-				return "", fmt.Errorf("error getting absolute path: %w", err)
-			}
-
-			// Skip if already imported
-			if importedFiles[absImportPath] {
-				continue
-			}
-
-			// Mark as imported
-			importedFiles[absImportPath] = true
-
-			// Read the imported file
-			importContent, err := c.readContractFile(importFile)
-			if err != nil {
-				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
-			}
-
-			// Process the imported content recursively
-			processedImport, err := c.processLines(importContent)
-			if err != nil {
-				return "", err
-			}
-
-			// Add the processed import to output
-			output.WriteString(processedImport)
-			output.WriteString("\n")
-		} else {
-			// Regular line, add to output
-			output.WriteString(line)
-			output.WriteString("\n")
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error scanning input: %w", err)
-	}
-
-	return output.String(), nil
-}
-
-func (c *deployContract) readContractFile(filePath string) (string, error) {
-	// if the file path is a url, read it from the web
-	if strings.HasPrefix(filePath, "http") {
-		// search in the web
-		req, err := http.NewRequest("GET", filePath, nil)
-		if err != nil {
-			return "", err
-		}
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-		fileBytes, _ := ioutil.ReadAll(resp.Body)
-		return string(fileBytes), nil
-	}
-
-	// search in the local file system
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return "", err
-	}
-	fileBytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return "", err
-	}
-	return string(fileBytes), nil
-}
-
-func (c *deployContract) readContract(filePath string) (string, error) {
-	// Reset imported files tracking for each new processing
-	importedFiles = make(map[string]bool)
-	// read the contract file
-	output, err := c.readContractFile(filePath)
-	if err != nil {
-		return "", err
-	}
-	// process the contract file for import statements
-	return c.processLines(output)
-}
-
 func (c *deployContract) parse(args string) (string, *big.Int, string, string, string, error) {
 	splitArgs := context.SplitSpaceAndAccent(args, false)
 	if len(splitArgs) < 4 {
@@ -185,7 +59,7 @@ func (c *deployContract) parse(args string) (string, *big.Int, string, string, s
 	}
 
 	defPath := splitArgs[3].Text
-	if _, err := c.readContract(defPath); err != nil {
+	if _, err := readContract(defPath); err != nil {
 		return "", nil, "", "", "", fmt.Errorf("fail to read a contract def file %s: %s", splitArgs[3].Text, err.Error())
 	}
 
@@ -207,7 +81,7 @@ func (c *deployContract) parse(args string) (string, *big.Int, string, string, s
 func (c *deployContract) Run(args string) (string, uint64, []*types.Event, error) {
 	accountName, amount, contractName, defPath, constuctorArg, _ := c.parse(args)
 
-	defByte, err := c.readContract(defPath)
+	defByte, err := readContract(defPath)
 	if err != nil {
 		return "", 0, nil, err
 	}

--- a/cmd/brick/exec/pack.go
+++ b/cmd/brick/exec/pack.go
@@ -1,0 +1,160 @@
+package exec
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Set to track imported files
+var importedFiles = make(map[string]bool)
+
+// ProcessLines processes a string containing contract code, handling imports
+func processLines(input string) (string, error) {
+
+	// Create a string builder for the output
+	var output strings.Builder
+
+	// Process each line
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if line starts with "import "
+		if strings.HasPrefix(line, "import ") {
+			// Extract the file name from import statement
+			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
+
+			// Check if it has minimum length for a valid import
+			if len(importLine) < 3 {
+				return "", fmt.Errorf("invalid import format: %s", line)
+			}
+
+			// Check if it starts with a valid quote character
+			quoteChar := importLine[0]
+			if quoteChar != '"' && quoteChar != '\'' {
+				return "", fmt.Errorf("import statement must use quotes: %s", line)
+			}
+
+			// Check if it ends with the same quote character
+			if importLine[len(importLine)-1] != quoteChar {
+				return "", fmt.Errorf("mismatched quotes in import: %s", line)
+			}
+
+			// Extract the file path between quotes
+			importFile := importLine[1 : len(importLine)-1]
+
+			// Get absolute path to check for circular imports
+			absImportPath, err := filepath.Abs(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error getting absolute path: %w", err)
+			}
+
+			// Skip if already imported
+			if importedFiles[absImportPath] {
+				continue
+			}
+
+			// Mark as imported
+			importedFiles[absImportPath] = true
+
+			// Read the imported file
+			importContent, err := readContractFile(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
+			}
+
+			// Process the imported content recursively
+			processedImport, err := processLines(importContent)
+			if err != nil {
+				return "", err
+			}
+
+			// Add the processed import to output
+			output.WriteString(processedImport)
+			output.WriteString("\n")
+		} else {
+			// Regular line, add to output
+			output.WriteString(line)
+			output.WriteString("\n")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error scanning input: %w", err)
+	}
+
+	return output.String(), nil
+}
+
+func readContractFile(filePath string) (string, error) {
+	// if the file path is a url, read it from the web
+	if strings.HasPrefix(filePath, "http") {
+		// search in the web
+		req, err := http.NewRequest("GET", filePath, nil)
+		if err != nil {
+			return "", err
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		fileBytes, _ := ioutil.ReadAll(resp.Body)
+		return string(fileBytes), nil
+	}
+
+	// search in the local file system
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return "", err
+	}
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(fileBytes), nil
+}
+
+func readContract(filePath string) (string, error) {
+	// Reset imported files tracking for each new processing
+	importedFiles = make(map[string]bool)
+	// read the contract file
+	output, err := readContractFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	// process the contract file for import statements
+	return processLines(output)
+}
+
+// ExecutePack reads a contract from inputFile and packs it, optionally writing to outputFile
+func ExecutePack(inputFile, outputFile string) int {
+
+	// Read the contract from the input file
+	packedCode, err := readContract(inputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading contract: %s\n", err)
+		return 1
+	}
+
+	// If output file is not specified, print an error
+	if outputFile == "" {
+		fmt.Fprintf(os.Stderr, "Error: output file is required\n")
+		return 1
+	}
+
+	// Write the packed code to the output file
+	err = ioutil.WriteFile(outputFile, []byte(packedCode), 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing to output file: %s\n", err)
+		return 1
+	}
+
+	fmt.Printf("Packed contract written to %s\n", outputFile)
+	return 0
+}

--- a/cmd/brick/exec/pack.go
+++ b/cmd/brick/exec/pack.go
@@ -1,164 +1,18 @@
 package exec
 
 import (
-	"bufio"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
+
+	pack "github.com/aergoio/aergo/v2/cmd/brick/pack"
 )
-
-// Set to track imported files
-var importedFiles = make(map[string]bool)
-
-// ProcessLines processes a string containing contract code, handling imports
-func processLines(input string, currentDir string) (string, error) {
-
-	// Create a string builder for the output
-	var output strings.Builder
-
-	// Process each line
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Check if line starts with "import "
-		if strings.HasPrefix(line, "import ") {
-			// Extract the file name from import statement
-			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
-
-			// Check if it has minimum length for a valid import
-			if len(importLine) < 3 {
-				return "", fmt.Errorf("invalid import format: %s", line)
-			}
-
-			// Check if it starts with a valid quote character
-			quoteChar := importLine[0]
-			if quoteChar != '"' && quoteChar != '\'' {
-				return "", fmt.Errorf("import statement must use quotes: %s", line)
-			}
-
-			// Check if it ends with the same quote character
-			if importLine[len(importLine)-1] != quoteChar {
-				return "", fmt.Errorf("mismatched quotes in import: %s", line)
-			}
-
-			// Extract the file path between quotes
-			importFile := importLine[1 : len(importLine)-1]
-
-			// If it's not a URL and not an absolute path, make it relative to the current file's directory
-			if !strings.HasPrefix(importFile, "http") && !filepath.IsAbs(importFile) {
-				importFile = filepath.Join(currentDir, importFile)
-			}
-
-			// Get absolute path to check for circular imports
-			absImportPath, err := filepath.Abs(importFile)
-			if err != nil {
-				return "", fmt.Errorf("error getting absolute path: %w", err)
-			}
-
-			// Skip if already imported
-			if importedFiles[absImportPath] {
-				continue
-			}
-
-			// Mark as imported
-			importedFiles[absImportPath] = true
-
-			// Read the imported file
-			importContent, err := readContractFile(importFile)
-			if err != nil {
-				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
-			}
-
-			// Get the directory of the imported file for nested imports
-			importedFileDir := filepath.Dir(importFile)
-
-			// Process the imported content recursively
-			processedImport, err := processLines(importContent, importedFileDir)
-			if err != nil {
-				return "", err
-			}
-
-			// Add the processed import to output
-			output.WriteString(processedImport)
-			output.WriteString("\n")
-		} else {
-			// Regular line, add to output
-			output.WriteString(line)
-			output.WriteString("\n")
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error scanning input: %w", err)
-	}
-
-	return output.String(), nil
-}
-
-func readContractFile(filePath string) (string, error) {
-	// if the file path is a url, read it from the web
-	if strings.HasPrefix(filePath, "http") {
-		// search in the web
-		req, err := http.NewRequest("GET", filePath, nil)
-		if err != nil {
-			return "", err
-		}
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-		fileBytes, _ := ioutil.ReadAll(resp.Body)
-		return string(fileBytes), nil
-	}
-
-	// search in the local file system
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return "", err
-	}
-	fileBytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return "", err
-	}
-	return string(fileBytes), nil
-}
-
-func readContract(filePath string) (string, error) {
-	// Reset imported files tracking for each new processing
-	importedFiles = make(map[string]bool)
-
-	// Get the absolute path of the main file
-	absPath, err := filepath.Abs(filePath)
-	if err != nil {
-		return "", fmt.Errorf("error getting absolute path: %w", err)
-	}
-
-	// Get the directory of the main file
-	mainFileDir := filepath.Dir(absPath)
-
-	// Mark the main file as imported
-	importedFiles[absPath] = true
-
-	// read the contract file
-	output, err := readContractFile(filePath)
-	if err != nil {
-		return "", err
-	}
-
-	// process the contract file for import statements, passing the main file's directory
-	return processLines(output, mainFileDir)
-}
 
 // ExecutePack reads a contract from inputFile and packs it, optionally writing to outputFile
 func ExecutePack(inputFile, outputFile string) int {
 
 	// Read the contract from the input file
-	packedCode, err := readContract(inputFile)
+	packedCode, err := pack.ReadContract(inputFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading contract: %s\n", err)
 		return 1

--- a/cmd/brick/pack/pack.go
+++ b/cmd/brick/pack/pack.go
@@ -1,0 +1,155 @@
+package pack
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Set to track imported files
+var importedFiles = make(map[string]bool)
+
+// ProcessLines processes a string containing contract code, handling imports
+func processLines(input string, currentDir string) (string, error) {
+
+	// Create a string builder for the output
+	var output strings.Builder
+
+	// Process each line
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if line starts with "import "
+		if strings.HasPrefix(line, "import ") {
+			// Extract the file name from import statement
+			importLine := strings.TrimSpace(line[6:]) // Remove "import " prefix
+
+			// Check if it has minimum length for a valid import
+			if len(importLine) < 3 {
+				return "", fmt.Errorf("invalid import format: %s", line)
+			}
+
+			// Check if it starts with a valid quote character
+			quoteChar := importLine[0]
+			if quoteChar != '"' && quoteChar != '\'' {
+				return "", fmt.Errorf("import statement must use quotes: %s", line)
+			}
+
+			// Check if it ends with the same quote character
+			if importLine[len(importLine)-1] != quoteChar {
+				return "", fmt.Errorf("mismatched quotes in import: %s", line)
+			}
+
+			// Extract the file path between quotes
+			importFile := importLine[1 : len(importLine)-1]
+
+			// If it's not a URL and not an absolute path, make it relative to the current file's directory
+			if !strings.HasPrefix(importFile, "http") && !filepath.IsAbs(importFile) {
+				importFile = filepath.Join(currentDir, importFile)
+			}
+
+			// Get absolute path to check for circular imports
+			absImportPath, err := filepath.Abs(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error getting absolute path: %w", err)
+			}
+
+			// Skip if already imported
+			if importedFiles[absImportPath] {
+				continue
+			}
+
+			// Mark as imported
+			importedFiles[absImportPath] = true
+
+			// Read the imported file
+			importContent, err := readContractFile(importFile)
+			if err != nil {
+				return "", fmt.Errorf("error importing file '%s': %w", importFile, err)
+			}
+
+			// Get the directory of the imported file for nested imports
+			importedFileDir := filepath.Dir(importFile)
+
+			// Process the imported content recursively
+			processedImport, err := processLines(importContent, importedFileDir)
+			if err != nil {
+				return "", err
+			}
+
+			// Add the processed import to output
+			output.WriteString(processedImport)
+			output.WriteString("\n")
+		} else {
+			// Regular line, add to output
+			output.WriteString(line)
+			output.WriteString("\n")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error scanning input: %w", err)
+	}
+
+	return output.String(), nil
+}
+
+func readContractFile(filePath string) (string, error) {
+	// if the file path is a url, read it from the web
+	if strings.HasPrefix(filePath, "http") {
+		// search in the web
+		req, err := http.NewRequest("GET", filePath, nil)
+		if err != nil {
+			return "", err
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		fileBytes, _ := ioutil.ReadAll(resp.Body)
+		return string(fileBytes), nil
+	}
+
+	// search in the local file system
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return "", err
+	}
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(fileBytes), nil
+}
+
+func ReadContract(filePath string) (string, error) {
+	// Reset imported files tracking for each new processing
+	importedFiles = make(map[string]bool)
+
+	// Get the absolute path of the main file
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", fmt.Errorf("error getting absolute path: %w", err)
+	}
+
+	// Get the directory of the main file
+	mainFileDir := filepath.Dir(absPath)
+
+	// Mark the main file as imported
+	importedFiles[absPath] = true
+
+	// read the contract file
+	output, err := readContractFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	// process the contract file for import statements, passing the main file's directory
+	return processLines(output, mainFileDir)
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -12,6 +12,9 @@ echo "Running integration tests for $arg"
 if [ "$arg" == "brick" ]; then
   # run the brick test
   ../bin/brick -V test.brick
+  ../bin/brick pack test-import-1.lua
+  # compare the output with the expected output. it will fail if the output is different.
+  diff test-import-1-bundle.lua test-import-expected-bundle.lua
   exit 0
 fi
 

--- a/tests/test-import-1.lua
+++ b/tests/test-import-1.lua
@@ -1,0 +1,8 @@
+import "test-import-2.lua"
+import "test-name-service.lua"
+
+function test()
+  return "test"
+end
+
+abi.register(test)

--- a/tests/test-import-2.lua
+++ b/tests/test-import-2.lua
@@ -1,4 +1,5 @@
 import "test-name-service.lua"
+import "https://raw.githubusercontent.com/aergoio/aergo-contract-ex/refs/heads/master/contracts/typecheck/typecheck.lua"
 
 function test2()
   return "test2"

--- a/tests/test-import-2.lua
+++ b/tests/test-import-2.lua
@@ -1,0 +1,7 @@
+import "test-name-service.lua"
+
+function test2()
+  return "test2"
+end
+
+abi.register(test2)

--- a/tests/test-import-expected-bundle.lua
+++ b/tests/test-import-expected-bundle.lua
@@ -1,0 +1,73 @@
+
+function resolve(name)
+  return name_service.resolve(name)
+end
+
+abi.register(resolve)
+
+-- from http://lua-users.org/wiki/LuaTypeChecking
+--
+-- Type check function that decorates functions.
+-- supported type: string, number, function, boolean, nil, userdata, address, bignum
+-- Example:
+--   sum = typecheck('number', 'number', '->', 'number')(
+--     function(x, y) return x + y end
+--   )
+
+function typecheck(...)
+  local types = {...}
+  
+  local function check(x, f)
+    if (x and f == 'address') then
+      assert(type(x) == 'string', "address must be string type") 
+      -- check address length
+      assert(52 == #x, string.format("invalid address length: %s (%s)", x, #x))
+      -- check character
+      local invalidChar = string.match(x, '[^123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]')
+      assert(nil == invalidChar,
+        string.format("invalid address format: %s contains invalid char %s", x, invalidChar or 'nil'))
+    elseif (x and f == 'bignum') then
+      -- check bignum
+      assert(bignum.isbignum(x), string.format("invalid format: %s != %s", type(x), f))
+    else
+      -- check default lua types
+      assert(type(x) == f, string.format("invalid format: %s != %s", type(x), f or 'nil'))
+    end
+  end
+  
+  return function(f)
+    local function returncheck(i, ...)
+      -- Check types of return values.
+      if types[i] == "->" then i = i + 1 end
+      local j = i
+      while types[i] ~= nil do
+        check(select(i - j + 1, ...), types[i])
+        i = i + 1
+      end
+      return ...
+    end
+    return function(...)
+      -- Check types of input parameters.
+      local i = 1
+      while types[i] ~= nil and types[i] ~= "->" do
+        check(select(i, ...), types[i])
+        i = i + 1
+      end
+      return returncheck(i, f(...))  -- call function
+    end
+  end
+end
+
+
+function test2()
+  return "test2"
+end
+
+abi.register(test2)
+
+
+function test()
+  return "test"
+end
+
+abi.register(test)

--- a/tests/test.brick
+++ b/tests/test.brick
@@ -1,4 +1,5 @@
 inject me 10000000000
+deploy me 0 ct0 ./test-import-1.lua
 deploy me 0 ct1 ./basic.lua
 
 call me 0 ct1 set_value `[1,"first"]` ``


### PR DESCRIPTION
Contracts deployed with `brick` and `aergocli` now support the `import` statement in the following format:
```js
import 'file.lua'
import "path/to/another/file.lua"
import "https://raw.githubusercontent.com/aergoio/aergo-contract-ex/refs/heads/master/contracts/typecheck/typecheck.lua"

...
```
So there is no need to use `ship`