### PR TITLE
aergocli: add limits to event stream

### DIFF
--- a/cmd/aergocli/cmd/event.go
+++ b/cmd/aergocli/cmd/event.go
@@ -21,6 +21,7 @@ var start uint64
 var end uint64
 var desc bool
 var recentBlockCnt int32
+var maxEvents int32
 
 func init() {
 	eventCmd := &cobra.Command{
@@ -52,6 +53,7 @@ func init() {
 	streamCmd.Flags().StringVarP(&contractAddress, "address", "", "", "Contract Address")
 	streamCmd.Flags().StringVarP(&eventName, "event", "", "", "Event Name")
 	streamCmd.Flags().StringVarP(&argFilter, "argfilter", "", "", "argument filter")
+	streamCmd.Flags().Int32Var(&maxEvents, "limit", 0, "maximum number of events to receive (0 for unlimited)")
 	streamCmd.MarkFlagRequired("address")
 
 	eventCmd.AddCommand(
@@ -102,6 +104,8 @@ func execStreamEvent(cmd *cobra.Command, args []string) {
 		cmd.Printf("Failed: %s", err.Error())
 		return
 	}
+
+	var count int32
 	for {
 		event, err := stream.Recv()
 		if err != nil {
@@ -109,5 +113,10 @@ func execStreamEvent(cmd *cobra.Command, args []string) {
 			return
 		}
 		cmd.Println(jsonrpc.MarshalJSON(event))
+
+		count++
+		if maxEvents > 0 && count >= maxEvents {
+			return
+		}
 	}
 }

--- a/cmd/aergocli/cmd/event.go
+++ b/cmd/aergocli/cmd/event.go
@@ -22,7 +22,7 @@ var start uint64
 var end uint64
 var desc bool
 var recentBlockCnt int32
-var maxEvents int32
+var maxEvents int
 var eventTimeout int
 
 func init() {
@@ -55,7 +55,7 @@ func init() {
 	streamCmd.Flags().StringVarP(&contractAddress, "address", "", "", "Contract Address")
 	streamCmd.Flags().StringVarP(&eventName, "event", "", "", "Event Name")
 	streamCmd.Flags().StringVarP(&argFilter, "argfilter", "", "", "argument filter")
-	streamCmd.Flags().Int32Var(&maxEvents, "limit", 0, "maximum number of events to receive (0 for unlimited)")
+	streamCmd.Flags().IntVar(&maxEvents, "limit", 0, "maximum number of events to receive (0 for unlimited)")
 	streamCmd.Flags().IntVar(&eventTimeout, "timeout", 0, "maximum time to wait in seconds (0 for unlimited)")
 	streamCmd.MarkFlagRequired("address")
 
@@ -115,7 +115,7 @@ func execStreamEvent(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	var count int32
+	var count int
 	for {
 		event, err := stream.Recv()
 		if err != nil {

--- a/cmd/aergocli/cmd/event.go
+++ b/cmd/aergocli/cmd/event.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"context"
 	"log"
+	"os"
 	"time"
 
 	aergorpc "github.com/aergoio/aergo/v2/types"
@@ -112,7 +113,7 @@ func execStreamEvent(cmd *cobra.Command, args []string) {
 	stream, err := client.ListEventStream(ctx, filter)
 	if err != nil {
 		cmd.Printf("Failed: %s", err.Error())
-		return
+		os.Exit(1)
 	}
 
 	var count int
@@ -124,7 +125,7 @@ func execStreamEvent(cmd *cobra.Command, args []string) {
 			} else {
 				cmd.Printf("Failed: %s\n", err.Error())
 			}
-			return
+			os.Exit(1)
 		}
 		cmd.Println(jsonrpc.MarshalJSON(event))
 


### PR DESCRIPTION
This PR adds 2 limits to event stream on `aergocli`:

* Limit of events to receive
* Limit of time to wait (timeout)