### PR TITLE
attempt to fix force reset height

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # @copyright defined in aergo/LICENSE.txt
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(aergo NONE)
 

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -6,6 +6,7 @@
 package chain
 
 import (
+	"os"
 	"errors"
 	"fmt"
 	"math"
@@ -80,6 +81,8 @@ func (core *Core) init(dbType string, dataDir string, testModeOn bool, forceRese
 			logger.Fatal().Err(err).Uint64("height", forceResetHeight).Msg("failed to reset chaindb")
 			return err
 		}
+		logger.Info().Uint64("height", forceResetHeight).Msg("reset chaindb")
+		os.Exit(0)
 	}
 
 	// init statedb


### PR DESCRIPTION
when `forceresetheight` is used, `aergosvr` will exit just after removing new blocks from the db