### PR TITLE
upload binaries on releases

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -98,3 +98,13 @@ jobs:
       run: |
         echo "One or more integration tests failed!"
         exit 1
+
+    - name: Upload Binaries on Release
+      if: github.event_name == 'push' && github.ref_name == 'master' && github.ref_type == 'branch'
+      uses: actions/upload-artifact@v4
+      with:
+        name: aergo-binaries
+        retention-days: 30
+        path: |
+          bin/aergo*
+          bin/brick


### PR DESCRIPTION
This will upload the binaries built by the CI, but only when merging a PR to the `master` branch

These binaries can then be included on the release