### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/fee/gas.go
+++ b/fee/gas.go
@@ -34,10 +34,7 @@ func TxGas(payloadSize int) uint64 {
 	if IsZeroFee() {
 		return 0
 	}
-	size := paymentDataSize(int64(payloadSize))
-	if size > payloadMaxSize {
-		size = payloadMaxSize
-	}
+	size := min(paymentDataSize(int64(payloadSize)), payloadMaxSize)
 	txGas := txGasSize
 	payloadGas := uint64(size) * payloadGasSize
 	return txGas + payloadGas

--- a/fee/payload.go
+++ b/fee/payload.go
@@ -10,10 +10,7 @@ func PayloadFee(payloadSize int) *big.Int {
 	}
 
 	// set data fee
-	dataFee := paymentDataSize(int64(payloadSize))
-	if dataFee > payloadMaxSize {
-		dataFee = payloadMaxSize
-	}
+	dataFee := min(paymentDataSize(int64(payloadSize)), payloadMaxSize)
 	// return base fee + data fee
 	return new(big.Int).Add(baseTxAergo, CalcFee(aerPerByte, uint64(dataFee)))
 }
@@ -29,10 +26,7 @@ func MaxPayloadFee(payloadSize int) *big.Int {
 }
 
 func paymentDataSize(dataSize int64) int64 {
-	pSize := dataSize - freeByteSize
-	if pSize < 0 {
-		pSize = 0
-	}
+	pSize := max(dataSize-freeByteSize, 0)
 	return pSize
 }
 

--- a/p2p/p2putil/protobuf_test.go
+++ b/p2p/p2putil/protobuf_test.go
@@ -55,10 +55,7 @@ func Test_MarshalTxResp(t *testing.T) {
 				t.Errorf("Invalid proto error %s", err.Error())
 			}
 			actualSize := len(actual)
-			cut := 80
-			if actualSize < cut {
-				cut = actualSize
-			}
+			cut := min(actualSize, 80)
 			//fmt.Println("ACTUAL: ",hex.HexEncode(actual[:cut]))
 
 			assert.Equal(t, test.expectedSize, actualSize)

--- a/p2p/p2putil/util.go
+++ b/p2p/p2putil/util.go
@@ -162,10 +162,7 @@ func ComparePeerID(pid1, pid2 types.PeerID) int {
 	p2 := []byte(string(pid2))
 	l1 := len(p1)
 	l2 := len(p2)
-	compLen := l1
-	if l1 > l2 {
-		compLen = l2
-	}
+	compLen := min(l1, l2)
 
 	// check bytes
 	for i := 0; i < compLen; i++ {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
