### PR TITLE
fix build on new go versions

### DIFF
--- a/contract/lstate_factory.go
+++ b/contract/lstate_factory.go
@@ -76,7 +76,7 @@ func newLState() *LState {
 	return C.vm_newstate(C.int(currentForkVersion))
 }
 
-func (L *LState) close() {
+func closeLState(L *LState) {
 	if L != nil {
 		C.lua_close(L)
 	}


### PR DESCRIPTION
The build is failing on go 1.24 with the error message:

```
contract/lstate_factory.go:79:10: cannot define new methods on non-local type LState
```

Go 1.24 made stricter enforcement around type aliases

The fix is very simple. This function appears to not even be used.