### PR TITLE
Feat/turnoff compaction 234

### DIFF
--- a/chain/chaindb.go
+++ b/chain/chaindb.go
@@ -99,15 +99,17 @@ func (cdb *ChainDB) NewTx() db.Transaction {
 }
 
 func (cdb *ChainDB) Init(dbType string, dataDir string) error {
+	dbConfig := config.GetDBConfig()
+
 	if cdb.store == nil {
 		logger.Info().Str("datadir", dataDir).Msg("chain database initialized")
 		dbPath := common.PathMkdirAll(dataDir, chainDBName)
 		cdb.store = db.NewDB(db.ImplType(dbType), dbPath, db.Opt{
 			Name:  "compactionController",
-			Value: true,
+			Value: dbConfig.ControlCompaction,
 		}, db.Opt{
 			Name:  "compactionControllerPort",
-			Value: 17092,
+			Value: dbConfig.ChainDBPort,
 		})
 
 		cdb.store.SetCompactionEvent(func(event db.CompactionEvent) {

--- a/config/db_compaction.go
+++ b/config/db_compaction.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/aergoio/aergo-lib/log"
+)
+
+// This config is special config for NHIS site, and used only in aergosvr-2.3.x.
+// And, these configs are set by environment variables only.
+
+const (
+	TURN_OFF_CONTROL_COMPACTION = "TURN_OFF_CONTROL_COMPACTION"
+	COMPACTION_CHAIN_DB_PORT    = "COMPACTION_CHAIN_DB_PORT"
+	COMPACTION_STATE_DB_PORT    = "COMPACTION_STATE_DB_PORT"
+
+	DEFAULT_CHAIN_DB_PORT = 17092
+	DEFAULT_STATE_DB_PORT = 17091
+)
+
+// DBConfig defines configurations for db modnitoring
+type DBConfig struct {
+	ControlCompaction bool `mapstructure:"controlcompaction" description:"enable control compaction"`
+	StateDBPort       int  `mapstructure:"statedbport" description:"StateDB control port"`
+	ChainDBPort       int  `mapstructure:"chaindbport" description:"ChainDB control port"`
+}
+
+var (
+	logger = log.NewLogger("db_compaction")
+
+	defaultDBConfig *DBConfig
+)
+
+func init() {
+	var turnOffCompaction bool = false
+	var chainDBPort int = DEFAULT_CHAIN_DB_PORT
+	var stateDBPort int = DEFAULT_STATE_DB_PORT
+
+	chainDBPortVar := os.Getenv(COMPACTION_CHAIN_DB_PORT)
+	if chainDBPortVar != "" {
+		chainDBPort, _ = strconv.Atoi(chainDBPortVar)
+	}
+	stateDBPortVar := os.Getenv(COMPACTION_STATE_DB_PORT)
+	if stateDBPortVar != "" {
+		stateDBPort, _ = strconv.Atoi(stateDBPortVar)
+	}
+
+	turnOffCompactionVar := os.Getenv(TURN_OFF_CONTROL_COMPACTION)
+	if turnOffCompactionVar == "true" || turnOffCompactionVar == "1" {
+		logger.Info().Msg("turn off control compaction. the control port will not be opened.")
+		turnOffCompaction = true
+	} else {
+		logger.Debug().Int("chaindbPort", chainDBPort).Int("stateDBPort", stateDBPort).Msg("turn on control compaction. the control port will be opened.")
+	}
+	defaultDBConfig = &DBConfig{
+		ControlCompaction: !turnOffCompaction,
+		StateDBPort:       stateDBPort,
+		ChainDBPort:       chainDBPort,
+	}
+}
+
+func GetDBConfig() *DBConfig {
+	return defaultDBConfig
+}

--- a/docs/README-NHIS.md
+++ b/docs/README-NHIS.md
@@ -1,0 +1,11 @@
+# 
+
+This version have a feature for NHIS only. 
+
+It listen other two ports to control internal DB and cannot turn off by default.
+
+You need to set environment variable to turn off this feature.
+	
+- `TURN_OFF_CONTROL_COMPACTION` : Turn off control compaction feature. Default is `false`
+- `COMPACTION_CHAIN_DB_PORT` : Port for compaction chain DB. Default is `17092`
+- `COMPACTION_STATE_DB_PORT` : Port for compaction state DB. Default is `17091`

--- a/state/chainstatedb.go
+++ b/state/chainstatedb.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/aergoio/aergo-lib/db"
+	"github.com/aergoio/aergo/config"
 	"github.com/aergoio/aergo/internal/common"
 	"github.com/aergoio/aergo/internal/enc"
 	"github.com/aergoio/aergo/types"
@@ -43,6 +44,7 @@ func (sdb *ChainStateDB) Clone() *ChainStateDB {
 func (sdb *ChainStateDB) Init(dbType string, dataDir string, bestBlock *types.Block, test bool) error {
 	sdb.Lock()
 	defer sdb.Unlock()
+	dbConfig := config.GetDBConfig()
 
 	sdb.testmode = test
 	// init db
@@ -50,10 +52,10 @@ func (sdb *ChainStateDB) Init(dbType string, dataDir string, bestBlock *types.Bl
 		dbPath := common.PathMkdirAll(dataDir, stateName)
 		sdb.store = db.NewDB(db.ImplType(dbType), dbPath, db.Opt{
 			Name:  "compactionController",
-			Value: true,
+			Value: dbConfig.ControlCompaction,
 		}, db.Opt{
 			Name:  "compactionControllerPort",
-			Value: 17091,
+			Value: dbConfig.StateDBPort,
 		})
 		sdb.store.SetCompactionEvent(func(event db.CompactionEvent) {
 			if event.Start {


### PR DESCRIPTION
In the current version 2.3.4, the DB compaction control feature is always enabled, causing it to listen on two additional hardcoded ports, 17091 and 17092. This make it difficult to test or debug, or the use of state-tools, which depends on the code base of aergosvr.

This patch provides a method to disable this feature with minimal source code modification.

The DB compaction feature was also added to the latest version of aergosvr, 2.8.x, but that version does not require this patch as it offers a more improved method to enable or disable the feature.