### PR TITLE
Raft Consensus Hardening - 2.3.5

### DIFF
--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"time"
@@ -209,7 +210,24 @@ func SyncChain(hs *component.ComponentHub, targetHash []byte, targetNo types.Blo
 	logger.Info().Str("peer", p2putil.ShortForm(peerID)).Uint64("no", targetNo).
 		Str("hash", enc.ToString(targetHash)).Msg("request to sync for consensus")
 
-	notiC := make(chan error)
+	verifyTarget := func() error {
+		result, err := hs.RequestFuture(message.ChainSvc, &message.GetBlockByNo{BlockNo: targetNo},
+			time.Second, "consensus/chain.SyncChain.verifyTarget").Result()
+		block, err := message.GetHelper().ExtractBlockFromResponseAndError(result, err)
+		if err != nil {
+			return err
+		}
+		if block == nil || !bytes.Equal(block.BlockHash(), targetHash) {
+			return fmt.Errorf("%w: block %d hash does not match snapshot", ErrSyncChain, targetNo)
+		}
+		return nil
+	}
+
+	if best := GetBestBlock(hs); best != nil && best.BlockNo() >= targetNo {
+		return verifyTarget()
+	}
+
+	notiC := make(chan error, 1)
 	hs.Tell(message.SyncerSvc, &message.SyncStart{PeerID: peerID, TargetNo: targetNo, NotifyC: notiC})
 
 	// wait end of sync every 1sec
@@ -224,7 +242,13 @@ func SyncChain(hs *component.ComponentHub, targetHash []byte, targetNo types.Blo
 		}
 	}
 
+	if err := verifyTarget(); err != nil {
+		logger.Error().Err(err).Uint64("no", targetNo).
+			Str("hash", enc.ToString(targetHash)).
+			Msg("sync completed at a different block")
+		return err
+	}
+
 	logger.Info().Str("peer", p2putil.ShortForm(peerID)).Msg("succeeded to sync for consensus")
-	// TODO check best block is equal to target Hash/no
 	return nil
 }

--- a/consensus/chain/block.go
+++ b/consensus/chain/block.go
@@ -223,23 +223,32 @@ func SyncChain(hs *component.ComponentHub, targetHash []byte, targetNo types.Blo
 		return nil
 	}
 
-	if best := GetBestBlock(hs); best != nil && best.BlockNo() >= targetNo {
-		return verifyTarget()
-	}
-
-	notiC := make(chan error, 1)
-	hs.Tell(message.SyncerSvc, &message.SyncStart{PeerID: peerID, TargetNo: targetNo, NotifyC: notiC})
-
-	// wait end of sync every 1sec
-	select {
-	case err := <-notiC:
-		if err != nil {
-			logger.Error().Err(err).Uint64("no", targetNo).
-				Str("hash", enc.ToString(targetHash)).
-				Msg("failed to sync")
-
-			return err
+	for {
+		if best := GetBestBlock(hs); best != nil && best.BlockNo() >= targetNo {
+			return verifyTarget()
 		}
+
+		notiC := make(chan error, 1)
+		hs.Tell(message.SyncerSvc, &message.SyncStart{PeerID: peerID, TargetNo: targetNo, NotifyC: notiC})
+
+		err := <-notiC
+		if err == nil {
+			break
+		}
+		// Another sync is already running (e.g. orphan/tip-triggered). Wait
+		// for progress and retry instead of failing consensus sync.
+		if errors.Is(err, message.ErrSyncerBusy) {
+			logger.Info().Uint64("no", targetNo).
+				Str("hash", enc.ToString(targetHash)).
+				Msg("syncer busy; waiting to retry consensus sync")
+			time.Sleep(time.Second)
+			continue
+		}
+
+		logger.Error().Err(err).Uint64("no", targetNo).
+			Str("hash", enc.ToString(targetHash)).
+			Msg("failed to sync")
+		return err
 	}
 
 	if err := verifyTarget(); err != nil {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -97,6 +97,7 @@ type ChainDB interface {
 
 // AergoRaftAccessor is interface to access raft messaging. It is wrapping raft message with aergo internal types
 type AergoRaftAccessor interface {
+	ValidateMessage(peerID types.PeerID, m raftpb.Message) error
 	Process(ctx context.Context, peerID types.PeerID, m raftpb.Message) error
 	IsIDRemoved(peerID types.PeerID) bool
 	ReportUnreachable(peerID types.PeerID)

--- a/consensus/impl/raftv2/blockfactory.go
+++ b/consensus/impl/raftv2/blockfactory.go
@@ -692,6 +692,9 @@ func (bf *BlockFactory) ConfChange(req *types.MembershipChange) (*consensus.Memb
 	if bf.bpc == nil {
 		return nil, ErrorMembershipChange{ErrClusterNotReady}
 	}
+	if req == nil || req.Attr == nil {
+		return nil, ErrorMembershipChange{consensus.ErrInvalidMemberAttr}
+	}
 
 	if !bf.raftServer.IsLeader() {
 		return nil, ErrorMembershipChange{ErrNotRaftLeader}
@@ -727,6 +730,9 @@ func (bf *BlockFactory) MakeConfChangeProposal(req *types.MembershipChange) (*co
 
 	if bf.bpc == nil {
 		return nil, ErrorMembershipChange{ErrClusterNotReady}
+	}
+	if req == nil || req.Attr == nil {
+		return nil, consensus.ErrInvalidMemberAttr
 	}
 
 	cl := bf.bpc

--- a/consensus/impl/raftv2/blockfactory.go
+++ b/consensus/impl/raftv2/blockfactory.go
@@ -34,10 +34,11 @@ var (
 )
 
 var (
-	ErrClusterNotReady      = errors.New("cluster is not ready")
-	ErrNotRaftLeader        = errors.New("this node is not leader")
-	ErrInvalidConsensusName = errors.New("invalid consensus name")
-	ErrCancelGenerate       = errors.New("cancel generating block because work becomes stale")
+	ErrClusterNotReady         = errors.New("cluster is not ready")
+	ErrNotRaftLeader           = errors.New("this node is not leader")
+	ErrInvalidConsensusName    = errors.New("invalid consensus name")
+	ErrCancelGenerate          = errors.New("cancel generating block because work becomes stale")
+	ErrUnauthorizedBlockSigner = errors.New("block signer is not a current raft member")
 )
 
 func init() {
@@ -311,10 +312,17 @@ func (bf *BlockFactory) VerifySign(block *types.Block) error {
 
 // IsBlockValid checks the consensus level validity of a block.
 func (bf *BlockFactory) IsBlockValid(block *types.Block, bestBlock *types.Block) error {
-	// BlockFactory has no block valid check.
-	_, err := block.BPID()
+	producerID, err := block.BPID()
 	if err != nil {
 		return &consensus.ErrorConsensus{Msg: "bad public key in block", Err: err}
+	}
+	if bf.bpc != nil {
+		bf.bpc.Lock()
+		member := bf.bpc.Members().getMemberByPeerID(producerID)
+		bf.bpc.Unlock()
+		if member == nil {
+			return &consensus.ErrorConsensus{Msg: "unauthorized raft block signer", Err: ErrUnauthorizedBlockSigner}
+		}
 	}
 	return nil
 }

--- a/consensus/impl/raftv2/blockfactory.go
+++ b/consensus/impl/raftv2/blockfactory.go
@@ -747,96 +747,47 @@ func (bf *BlockFactory) MakeConfChangeProposal(req *types.MembershipChange) (*co
 	return proposal, nil
 }
 
-// getHardStateOfBlock is invoked on a live provider (this node) to answer a
-// recovering requester's GetClusterInfo request. `requesterBestHash` is the
-// hash of the REQUESTER's best block (not ours); we look up which raft
-// (term, index) that block was committed at, so the requester can bootstrap
-// its WAL from there.
-//
-// Lookup strategy, from most to least precise:
-//  1. Exact match: our WAL still has the raft entry for requesterBestHash.
-//  2. Upward scan: that entry was compacted/missing, but a newer block on our
-//     chain does have an entry. Return that — it represents the oldest raft
-//     index we can safely serve to the requester (any older index has been
-//     compacted here and cannot be served via MsgApp anyway).
-//  3. Snapshot fallback: we have no block entry in WAL covering the requester
-//     (deeply lagging requester, pruned r_inv index, or fresh cluster).
-//     Return our latest raft snapshot metadata, which is by definition a
-//     valid raft checkpoint.
-//
-// NOTE on naming: `requesterBestHash` / `requesterBlock` refer to the REMOTE
-// node that sent us this request. `myTip` is OUR (the provider's) local best
-// block. In a normal recovery scenario myTip >> requesterBlock, so the
-// upward scan has plenty of blocks to probe. If instead the requester is at
-// or past our tip, the scan bounds collapse to an empty range and we fall
-// through to (3).
-//
-// Prior to this function, only (1) and a downward scan (which can never
-// succeed if the requester's block is pre-retention — every older block is
-// also pre-retention) were attempted. That caused ImportExistingCluster to
-// fatal on recovering nodes whose backup was older than our WAL retention
-// window.
-//
-// NOTE: When the caller receives a hardstate from (2) or (3), its local
-// bestblock is older than the block that hardstate corresponds to. After
-// ResetWAL, the caller's chain DB will have a gap relative to the raft
-// state. That gap is bridged at runtime by the block syncer and/or by a
-// MsgSnap from the raft leader; handling it is outside the scope of this
-// function.
+// getHardStateOfBlock returns only a checkpoint that represents the
+// requester's exact local best block. Pairing a newer raft index with an older
+// backup fabricates applied state and can let the recovering node vote or lead
+// before its chain reaches that index. Callers that still need to recover from
+// an older backup must sync the chain forward to a tip that still has an exact
+// checkpoint, then retry.
 func (bf *BlockFactory) getHardStateOfBlock(requesterBestHash []byte) (*types.HardStateInfo, error) {
-	// Upper bound on how many blocks to probe during the upward scan. The
-	// first successful probe returns immediately, so this only matters when
-	// the gap between the requester's bestblock and the oldest in-WAL entry
-	// is very large (deep-old backups); in that case we'd rather fall
-	// through to the snapshot fallback than iterate for seconds.
-	const maxUpwardScan = 10000
-
 	requesterBlock, err := bf.GetBlock(requesterBestHash)
-	if err == nil {
-		// (1) Exact match.
-		if entry, err := bf.ChainWAL.GetRaftEntryOfBlock(requesterBestHash); err == nil {
-			logger.Debug().Uint64("term", entry.Term).Uint64("commit", entry.Index).Msg("get hardstate of block")
-			return &types.HardStateInfo{Term: entry.Term, Commit: entry.Index}, nil
-		}
-
-		logger.Warn().Uint64("requester_no", requesterBlock.BlockNo()).Msg("raft entry for requested block hash is not in WAL; scanning newer blocks on this node")
-
-		// (2) Upward scan from the requester's block toward OUR tip.
-		// Since we (the provider) are typically ahead of the requester,
-		// this range is non-empty in normal recovery scenarios.
-		if myTip, err := bf.GetBestBlock(); err == nil && myTip != nil {
-			end := requesterBlock.BlockNo() + maxUpwardScan
-			if end > myTip.BlockNo() {
-				end = myTip.BlockNo()
-			}
-			for i := requesterBlock.BlockNo() + 1; i <= end; i++ {
-				hash, err := bf.GetHashByNo(i)
-				if err != nil {
-					continue
-				}
-				entry, err := bf.ChainWAL.GetRaftEntryOfBlock(hash)
-				if err != nil {
-					continue
-				}
-				logger.Warn().Uint64("requester_no", requesterBlock.BlockNo()).Uint64("returned_no", i).Uint64("term", entry.Term).Uint64("commit", entry.Index).Msg("raft entry for requested block was pruned; returning closest newer entry from our WAL")
-				return &types.HardStateInfo{Term: entry.Term, Commit: entry.Index}, nil
-			}
-		}
-	} else {
-		logger.Warn().Str("hash", base58.Encode(requesterBestHash)).Err(err).Msg("requested block not in our chain; falling back to local snapshot")
+	if err != nil {
+		return nil, fmt.Errorf("requested backup block %s is not in provider chain: %w",
+			base58.Encode(requesterBestHash), err)
 	}
 
-	// (3) Snapshot fallback. GetSnapshot returns OUR most recently persisted
-	// raft snapshot, whose metadata is always a valid checkpoint.
+	if entry, err := bf.ChainWAL.GetRaftEntryOfBlock(requesterBestHash); err == nil &&
+		entry.Type == consensus.EntryBlock && entry.Term > 0 && entry.Index > 0 &&
+		bytes.Equal(entry.Data, requesterBestHash) {
+		logger.Debug().Uint64("term", entry.Term).Uint64("commit", entry.Index).Msg("get exact hardstate of backup block")
+		return &types.HardStateInfo{Term: entry.Term, Commit: entry.Index}, nil
+	}
+
+	// A compacted WAL is still safe when its persisted snapshot names this
+	// exact block. Any newer snapshot belongs to application state the
+	// requester does not yet have and must not be used to reset its WAL.
 	if snap, err := bf.ChainWAL.GetSnapshot(); err == nil && snap != nil {
-		logger.Warn().Uint64("snap_index", snap.Metadata.Index).Uint64("snap_term", snap.Metadata.Term).Msg("returning our latest raft snapshot hardstate as fallback")
-		return &types.HardStateInfo{Term: snap.Metadata.Term, Commit: snap.Metadata.Index}, nil
+		var data consensus.SnapshotData
+		if snap.Metadata.Term > 0 && snap.Metadata.Index > 0 &&
+			data.Decode(snap.Data) == nil &&
+			data.Chain.No == requesterBlock.BlockNo() &&
+			bytes.Equal(data.Chain.Hash, requesterBestHash) {
+			logger.Debug().Uint64("term", snap.Metadata.Term).Uint64("commit", snap.Metadata.Index).Msg("get exact hardstate from matching snapshot")
+			return &types.HardStateInfo{Term: snap.Metadata.Term, Commit: snap.Metadata.Index}, nil
+		}
 	}
 
-	return nil, fmt.Errorf("no raft entry or snapshot available to serve hardstate for requested hash")
+	return nil, fmt.Errorf("backup block %d (%s) is older than retained raft history; sync chain forward then retry",
+		requesterBlock.BlockNo(), base58.Encode(requesterBestHash))
 }
 
-// ClusterInfo returns members of cluster and hardstate info corresponding to best block hash
+// ClusterInfo returns members of cluster and hardstate info corresponding to best block hash.
+// Hardstate lookup failures are non-fatal so a recovering node can still learn membership,
+// sync the missing chain delta, and retry for an exact checkpoint.
 func (bf *BlockFactory) ClusterInfo(bestBlockHash []byte) *types.GetClusterInfoResponse {
 	var (
 		hardStateInfo *types.HardStateInfo
@@ -849,18 +800,19 @@ func (bf *BlockFactory) ClusterInfo(bestBlockHash []byte) *types.GetClusterInfoR
 		return &types.GetClusterInfoResponse{Error: ErrClusterNotReady.Error()}
 	}
 
-	if bestBlockHash != nil {
-		if hardStateInfo, err = bf.getHardStateOfBlock(bestBlockHash); err != nil {
-			return &types.GetClusterInfoResponse{Error: err.Error()}
-		}
-	}
-
 	if mbrAttrs, err = bf.bpc.getMemberAttrs(); err != nil {
 		return &types.GetClusterInfoResponse{Error: err.Error()}
 	}
 
 	if bestBlock, err = bf.GetBestBlock(); err != nil {
 		return &types.GetClusterInfoResponse{Error: err.Error()}
+	}
+
+	if bestBlockHash != nil {
+		if hardStateInfo, err = bf.getHardStateOfBlock(bestBlockHash); err != nil {
+			logger.Warn().Err(err).Str("hash", base58.Encode(bestBlockHash)).
+				Msg("exact hardstate unavailable; returning cluster membership without hardstate")
+		}
 	}
 
 	return &types.GetClusterInfoResponse{ChainID: bf.bpc.chainID, ClusterID: bf.bpc.ClusterID(), MbrAttrs: mbrAttrs, BestBlockNo: bestBlock.BlockNo(), HardStateInfo: hardStateInfo}

--- a/consensus/impl/raftv2/cluster.go
+++ b/consensus/impl/raftv2/cluster.go
@@ -206,6 +206,9 @@ func NewClusterFromMemberAttrs(clusterID uint64, chainID []byte, memberAttrs []*
 	cl := NewCluster(chainID, nil, "", "", 0, nil)
 
 	for _, mbrAttr := range memberAttrs {
+		if mbrAttr == nil {
+			return nil, consensus.ErrInvalidMemberAttr
+		}
 		var mbr consensus.Member
 
 		mbr.SetAttr(mbrAttr)
@@ -299,12 +302,18 @@ func (cl *Cluster) Recover(snapshot *raftpb.Snapshot) (bool, error) {
 
 	// members restore
 	for _, mbr := range snapdata.Members {
+		if err := cl.isValidMember(mbr); err != nil {
+			return false, err
+		}
 		if err := cl.addMember(mbr, true); err != nil {
 			return false, err
 		}
 	}
 
 	for _, mbr := range snapdata.RemovedMembers {
+		if mbr == nil || !mbr.IsValid() {
+			return false, ErrInvalidMember
+		}
 		cl.RemovedMembers().add(mbr)
 	}
 
@@ -404,6 +413,10 @@ func (cl *Cluster) getMemberPeerAddress(id uint64) (types.PeerID, error) {
 func (cl *Cluster) isValidMember(member *consensus.Member) error {
 	cl.Lock()
 	defer cl.Unlock()
+
+	if member == nil || !member.IsValid() {
+		return ErrInvalidMember
+	}
 
 	mbrs := cl.members
 
@@ -849,6 +862,9 @@ func (cl *Cluster) toConsensusInfo() *types.ConsensusInfo {
 }
 
 func (cl *Cluster) NewMemberFromAddReq(req *types.MembershipChange) (*consensus.Member, error) {
+	if req == nil || req.Attr == nil {
+		return nil, consensus.ErrInvalidMemberAttr
+	}
 	if len(req.Attr.Name) == 0 || len(req.Attr.Address) == 0 || len(req.Attr.PeerID) == 0 {
 		return nil, consensus.ErrInvalidMemberAttr
 	}
@@ -857,6 +873,9 @@ func (cl *Cluster) NewMemberFromAddReq(req *types.MembershipChange) (*consensus.
 }
 
 func (cl *Cluster) NewMemberFromRemoveReq(req *types.MembershipChange) (*consensus.Member, error) {
+	if req == nil || req.Attr == nil {
+		return nil, consensus.ErrInvalidMemberAttr
+	}
 	if req.Attr.ID == consensus.InvalidMemberID {
 		return nil, consensus.ErrInvalidMemberID
 	}
@@ -909,6 +928,9 @@ func (cl *Cluster) makeProposal(req *types.MembershipChange, nowait bool) (*cons
 	if cl.savedChange != nil {
 		logger.Error().Str("cc", types.RaftConfChangeToString(cl.savedChange.Cc)).Msg("already exist pending conf change")
 		return nil, ErrPendingConfChange
+	}
+	if req == nil || req.Attr == nil {
+		return nil, consensus.ErrInvalidMemberAttr
 	}
 
 	var (

--- a/consensus/impl/raftv2/cluster.go
+++ b/consensus/impl/raftv2/cluster.go
@@ -395,6 +395,12 @@ func (cl *Cluster) getAnyPeerAddressToSync() (types.PeerID, error) {
 	return "", ErrNoEnableSyncPeer
 }
 
+func (cl *Cluster) getMemberPeerAddress(id uint64) (types.PeerID, error) {
+	cl.Lock()
+	defer cl.Unlock()
+	return cl.Members().getMemberPeerAddress(id)
+}
+
 func (cl *Cluster) isValidMember(member *consensus.Member) error {
 	cl.Lock()
 	defer cl.Unlock()

--- a/consensus/impl/raftv2/cluster.go
+++ b/consensus/impl/raftv2/cluster.go
@@ -499,9 +499,9 @@ func (cl *Cluster) ValidateAndMergeExistingCluster(existingCl *Cluster) bool {
 		return false
 	}
 
-	// TODO check my network config is equal to member of remote
 	if enc.ToString(remoteMember.PeerID) != cl.NodePeerID() {
 		logger.Error().Msg("peerid is different with peerid of member of existing cluster")
+		return false
 	}
 
 	cl.members = existingCl.Members()

--- a/consensus/impl/raftv2/cluster.go
+++ b/consensus/impl/raftv2/cluster.go
@@ -540,6 +540,8 @@ func (cl *Cluster) getMemberAttrs() ([]*types.MemberAttr, error) {
 
 // IsIDRemoved return true if given raft id is not exist in cluster
 func (cl *Cluster) IsIDRemoved(id uint64) bool {
+	cl.Lock()
+	defer cl.Unlock()
 	return cl.RemovedMembers().isExist(id)
 }
 

--- a/consensus/impl/raftv2/cluster_test.go
+++ b/consensus/impl/raftv2/cluster_test.go
@@ -130,6 +130,11 @@ func TestClusterConfChange(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
+	_, err = cl.makeProposal(nil, true)
+	assert.Error(t, err, "nil membership request")
+	_, err = cl.makeProposal(&types.MembershipChange{}, true)
+	assert.Error(t, err, "nil membership attributes")
+
 	// normal case
 	req := &types.MembershipChange{
 		Type: types.MembershipChangeType_ADD_MEMBER,
@@ -161,6 +166,13 @@ func TestClusterConfChange(t *testing.T) {
 	}
 	_, err = cl.makeProposal(req, true)
 	assert.Error(t, err, "duplicate peerid")
+
+	req = &types.MembershipChange{
+		Type: types.MembershipChangeType_ADD_MEMBER,
+		Attr: &types.MemberAttr{Name: "test4", Address: "/ip4/127.0.0.1/tcp/10004", PeerID: []byte("not-a-peer-id")},
+	}
+	_, err = cl.makeProposal(req, true)
+	assert.Error(t, err, "malformed peerid")
 
 	req = &types.MembershipChange{
 		Type: types.MembershipChangeType_REMOVE_MEMBER,

--- a/consensus/impl/raftv2/cluster_test.go
+++ b/consensus/impl/raftv2/cluster_test.go
@@ -208,3 +208,17 @@ func TestClusterEqual(t *testing.T) {
 
 	assert.False(t, cl.isAllMembersEqual(testMbrs, nil))
 }
+
+func TestValidateAndMergeExistingClusterRejectsPeerIDMismatch(t *testing.T) {
+	chainID := []byte("test-chain")
+	local := NewCluster(chainID, nil, "joining-node", testPeerIDs[0], 0, nil)
+
+	remote, err := NewClusterFromMemberAttrs(1, chainID, []*types.MemberAttr{{
+		ID:      1,
+		Name:    "joining-node",
+		Address: "/ip4/127.0.0.1/tcp/11001",
+		PeerID:  []byte(testPeerIDs[1]),
+	}})
+	assert.NoError(t, err)
+	assert.False(t, local.ValidateAndMergeExistingCluster(remote))
+}

--- a/consensus/impl/raftv2/raftserver.go
+++ b/consensus/impl/raftv2/raftserver.go
@@ -54,18 +54,22 @@ var (
 )
 
 var (
-	ErrRaftNotReady               = errors.New("raft library is not initialized")
-	ErrCCAlreadyApplied           = errors.New("conf change entry is already applied")
-	ErrInvalidMember              = errors.New("member of conf change is invalid")
-	ErrCCAlreadyAdded             = errors.New("member has already added")
-	ErrCCAlreadyRemoved           = errors.New("member has already removed")
-	ErrCCNoMemberToRemove         = errors.New("there is no member to remove")
-	ErrEmptySnapshot              = errors.New("received empty snapshot")
-	ErrInvalidRaftIdentity        = errors.New("raft identity is not set")
-	ErrProposeNilBlock            = errors.New("proposed block is nil")
-	ErrUnknownRaftPeer            = errors.New("raft message sender is not a cluster member")
-	ErrRaftSenderMismatch         = errors.New("raft message sender does not match authenticated peer")
-	ErrRaftTargetMismatch         = errors.New("raft message is addressed to another node")
+	ErrRaftNotReady              = errors.New("raft library is not initialized")
+	ErrCCAlreadyApplied          = errors.New("conf change entry is already applied")
+	ErrInvalidMember             = errors.New("member of conf change is invalid")
+	ErrCCAlreadyAdded            = errors.New("member has already added")
+	ErrCCAlreadyRemoved          = errors.New("member has already removed")
+	ErrCCNoMemberToRemove        = errors.New("there is no member to remove")
+	ErrEmptySnapshot             = errors.New("received empty snapshot")
+	ErrInvalidRaftIdentity       = errors.New("raft identity is not set")
+	ErrProposeNilBlock           = errors.New("proposed block is nil")
+	ErrUnknownRaftPeer           = errors.New("raft message sender is not a cluster member")
+	ErrRaftSenderMismatch        = errors.New("raft message sender does not match authenticated peer")
+	ErrRaftTargetMismatch        = errors.New("raft message is addressed to another node")
+	ErrSnapshotBlockMismatch     = errors.New("snapshot block hash does not match synchronized chain")
+	ErrStaleRaftSnapshot         = errors.New("raft snapshot is stale")
+	ErrUnexpectedRaftSnapshot    = errors.New("raft snapshot is not from the current leader")
+	ErrSnapshotMembershipMismatch = errors.New("snapshot membership does not match raft conf state")
 )
 
 const (
@@ -1037,28 +1041,11 @@ func (rs *raftServer) triggerSnapshot() {
 }
 
 func (rs *raftServer) publishSnapshot(snapshotToSave raftpb.Snapshot) error {
-	updateProgress := func() error {
-		var snapdata = &consensus.SnapshotData{}
-
-		err := snapdata.Decode(snapshotToSave.Data)
-		if err != nil {
-			logger.Error().Msg("failed to unmarshal snapshot data to progress")
-			return err
-		}
-
-		block, err := rs.walDB.GetBlockByNo(snapdata.Chain.No)
-		if err != nil {
-			logger.Fatal().Msg("failed to get synchronized block")
-			return err
-		}
-
-		rs.commitProgress.UpdateConnect(&commitEntry{block: block, index: snapshotToSave.Metadata.Index, term: snapshotToSave.Metadata.Term})
-
-		return nil
-	}
-
 	if raftlib.IsEmptySnap(snapshotToSave) {
 		return ErrEmptySnapshot
+	}
+	if err := validateSnapshotConsistency(&snapshotToSave); err != nil {
+		return err
 	}
 
 	logger.Info().Uint64("index", rs.snapshotIndex).Str("snap", consensus.SnapToString(&snapshotToSave, nil)).Msg("publishing snapshot at index")
@@ -1067,18 +1054,28 @@ func (rs *raftServer) publishSnapshot(snapshotToSave raftpb.Snapshot) error {
 	if snapshotToSave.Metadata.Index <= rs.appliedIndex {
 		logger.Fatal().Msgf("snapshot index [%d] should > progress.appliedIndex [%d] + 1", snapshotToSave.Metadata.Index, rs.appliedIndex)
 	}
+
+	var snapdata consensus.SnapshotData
+	if err := snapdata.Decode(snapshotToSave.Data); err != nil {
+		logger.Error().Err(err).Msg("failed to decode snapshot data")
+		return err
+	}
+	block, err := rs.walDB.GetBlockByNo(snapdata.Chain.No)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to get synchronized snapshot block")
+		return err
+	}
+	if !bytes.Equal(block.BlockHash(), snapdata.Chain.Hash) {
+		return ErrSnapshotBlockMismatch
+	}
 	//rs.commitC <- nil // trigger kvstore to load snapshot
 
 	rs.setConfState(&snapshotToSave.Metadata.ConfState)
 	rs.setSnapshotIndex(snapshotToSave.Metadata.Index)
 	rs.setAppliedIndex(snapshotToSave.Metadata.Index)
 
-	var (
-		isEqual bool
-		err     error
-	)
-
-	if isEqual, err = rs.cluster.Recover(&snapshotToSave); err != nil {
+	isEqual, err := rs.cluster.Recover(&snapshotToSave)
+	if err != nil {
 		return err
 	}
 
@@ -1086,7 +1083,8 @@ func (rs *raftServer) publishSnapshot(snapshotToSave raftpb.Snapshot) error {
 		rs.recoverTransport()
 	}
 
-	return updateProgress()
+	rs.commitProgress.UpdateConnect(&commitEntry{block: block, index: snapshotToSave.Metadata.Index, term: snapshotToSave.Metadata.Term})
+	return nil
 }
 
 func (rs *raftServer) recoverTransport() {
@@ -1616,6 +1614,31 @@ type raftHttpWrapper struct {
 	raftServer *raftServer
 }
 
+func validateSnapshotConsistency(snapshot *raftpb.Snapshot) error {
+	var data consensus.SnapshotData
+	if snapshot == nil || snapshot.Metadata.Index == 0 || data.Decode(snapshot.Data) != nil ||
+		len(data.Chain.Hash) == 0 || len(data.Members) != len(snapshot.Metadata.ConfState.Nodes) {
+		return ErrSnapshotMembershipMismatch
+	}
+
+	memberIDs := make(map[uint64]struct{}, len(data.Members))
+	for _, member := range data.Members {
+		if member == nil || !member.IsValid() {
+			return ErrSnapshotMembershipMismatch
+		}
+		if _, exists := memberIDs[member.ID]; exists {
+			return ErrSnapshotMembershipMismatch
+		}
+		memberIDs[member.ID] = struct{}{}
+	}
+	for _, id := range snapshot.Metadata.ConfState.Nodes {
+		if _, exists := memberIDs[id]; !exists {
+			return ErrSnapshotMembershipMismatch
+		}
+	}
+	return nil
+}
+
 func (rhw *raftHttpWrapper) ValidateMessage(peerID types.PeerID, m raftpb.Message) error {
 	member := rhw.GetMemberByPeerID(peerID)
 	if member == nil {
@@ -1628,6 +1651,20 @@ func (rhw *raftHttpWrapper) ValidateMessage(peerID types.PeerID, m raftpb.Messag
 	if m.To != rhw.raftServer.ID() {
 		return fmt.Errorf("%w: local %x, message target %x",
 			ErrRaftTargetMismatch, rhw.raftServer.ID(), m.To)
+	}
+	if m.Type == raftpb.MsgSnap {
+		if err := validateSnapshotConsistency(&m.Snapshot); err != nil {
+			return err
+		}
+		status := rhw.raftServer.Status()
+		if m.Term < status.Term || m.Snapshot.Metadata.Index <= status.Applied {
+			return fmt.Errorf("%w: term %d/%d, index %d/%d",
+				ErrStaleRaftSnapshot, m.Term, status.Term, m.Snapshot.Metadata.Index, status.Applied)
+		}
+		if m.Term == status.Term && status.Lead != HasNoLeader && m.From != status.Lead {
+			return fmt.Errorf("%w: leader %x, sender %x",
+				ErrUnexpectedRaftSnapshot, status.Lead, m.From)
+		}
 	}
 	return nil
 }

--- a/consensus/impl/raftv2/raftserver.go
+++ b/consensus/impl/raftv2/raftserver.go
@@ -176,14 +176,16 @@ func (cp *CommitProgress) GetConnect() *commitEntry {
 	cp.Lock()
 	defer cp.Unlock()
 
-	return &cp.connect
+	entry := cp.connect
+	return &entry
 }
 
 func (cp *CommitProgress) GetRequest() *commitEntry {
 	cp.Lock()
 	defer cp.Unlock()
 
-	return &cp.request
+	entry := cp.request
+	return &entry
 }
 
 func (cp *CommitProgress) IsReadyToPropose() bool {
@@ -1346,7 +1348,7 @@ func (rs *raftServer) publishEntries(ents []raftpb.Entry) bool {
 	isDuplicateCommit := func(block *types.Block) bool {
 		lastReq := rs.commitProgress.GetRequest()
 
-		if lastReq != nil && lastReq.block.BlockNo() >= block.BlockNo() {
+		if lastReq != nil && lastReq.block != nil && lastReq.block.BlockNo() >= block.BlockNo() {
 			if StopDupCommit {
 				logger.Fatal().Str("last", lastReq.block.ID()).Str("dup", block.ID()).Uint64("no", block.BlockNo()).Msg("fork occured by invalid commit entry")
 			} else {
@@ -1473,10 +1475,10 @@ func (rs *raftServer) updateTerm(term uint64) {
 }
 
 func (rs *raftServer) updateLeader(softState *raftlib.SoftState) {
-	if softState.Lead != rs.GetLeader() {
-		rs.Lock()
-		defer rs.Unlock()
+	rs.leaderStatus.Lock()
+	defer rs.leaderStatus.Unlock()
 
+	if softState.Lead != rs.leaderStatus.Leader {
 		rs.leaderStatus.Leader = softState.Lead
 
 		if rs.curTerm == 0 {
@@ -1515,8 +1517,12 @@ func (rs *raftServer) GetLeaderStatus() LeaderStatus {
 	rs.leaderStatus.RLock()
 	defer rs.leaderStatus.RUnlock()
 
-	tmpStatus := rs.leaderStatus
-	return tmpStatus
+	return LeaderStatus{
+		Leader:        rs.leaderStatus.Leader,
+		Term:          rs.leaderStatus.Term,
+		leaderChanged: rs.leaderStatus.leaderChanged,
+		IsLeader:      rs.leaderStatus.IsLeader,
+	}
 }
 
 // IsTermLeader returns true if this node is leader of given term
@@ -1806,11 +1812,17 @@ func (rhw *raftHttpWrapper) ReportSnapshot(peerID types.PeerID, status raftlib.S
 }
 
 func (rhw *raftHttpWrapper) GetMemberByID(id uint64) *consensus.Member {
-	return rhw.raftServer.cluster.Members().getMember(id)
+	cluster := rhw.raftServer.cluster
+	cluster.Lock()
+	defer cluster.Unlock()
+	return cluster.Members().getMember(id)
 }
 
 func (rhw *raftHttpWrapper) GetMemberByPeerID(peerID types.PeerID) *consensus.Member {
-	return rhw.raftServer.cluster.Members().getMemberByPeerID(peerID)
+	cluster := rhw.raftServer.cluster
+	cluster.Lock()
+	defer cluster.Unlock()
+	return cluster.Members().getMemberByPeerID(peerID)
 }
 
 func (rhw *raftHttpWrapper) SaveFromRemote(r io.Reader, id uint64, msg raftpb.Message) (int64, error) {

--- a/consensus/impl/raftv2/raftserver.go
+++ b/consensus/impl/raftv2/raftserver.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aergoio/aergo/chain"
+	conschain "github.com/aergoio/aergo/consensus/chain"
 	"github.com/aergoio/aergo/message"
 	"github.com/aergoio/aergo/p2p/p2pcommon"
 	"github.com/aergoio/aergo/pkg/component"
@@ -388,6 +389,10 @@ func (rs *raftServer) startRaft() {
 		if rs.UseBackup {
 			logger.Info().Msg("raft use given backup as wal")
 
+			if hardstateinfo, err = rs.resolveBackupHardState(hardstateinfo); err != nil {
+				logger.Fatal().Err(err).Msg("failed to resolve exact hardstate for backup recovery")
+			}
+
 			// Pass current cluster members into ResetWAL so the freshly
 			// written snapshot has a populated SnapshotData.Members *and*
 			// ConfState.Nodes. Without the latter, the first local snapshot
@@ -443,6 +448,8 @@ func (rs *raftServer) ImportExistingCluster() (*types.HardStateInfo, error) {
 
 	if hardstateinfo != nil {
 		logger.Info().Str("hardstate", hardstateinfo.ToString()).Msg("received hard state of best hash from remote cluster")
+	} else {
+		logger.Info().Msg("remote cluster returned membership without exact hardstate for local best block")
 	}
 
 	// config validate
@@ -451,6 +458,108 @@ func (rs *raftServer) ImportExistingCluster() (*types.HardStateInfo, error) {
 	}
 
 	return hardstateinfo, nil
+}
+
+// resolveBackupHardState returns an exact hardstate for the local best block.
+// If peers cannot map the current backup tip to retained raft history, sync the
+// missing chain delta first and retry so ResetWAL never jumps ahead of the chain.
+func (rs *raftServer) resolveBackupHardState(hardstateinfo *types.HardStateInfo) (*types.HardStateInfo, error) {
+	if hardstateinfo != nil {
+		return hardstateinfo, nil
+	}
+
+	logger.Warn().Msg("exact hardstate missing for backup tip; syncing chain forward before raft wal reset")
+	if err := rs.syncBackupChainToClusterTip(); err != nil {
+		return nil, err
+	}
+
+	_, hardstateinfo, err := rs.GetExistingCluster()
+	if err != nil {
+		return nil, err
+	}
+	if hardstateinfo == nil {
+		best, bestErr := rs.walDB.GetBestBlock()
+		if bestErr != nil {
+			return nil, fmt.Errorf("no exact hardstate after backup sync and failed to read local best: %w", bestErr)
+		}
+		return nil, fmt.Errorf("no exact hardstate after syncing backup to block %d (%s)",
+			best.BlockNo(), best.ID())
+	}
+
+	logger.Info().Str("hardstate", hardstateinfo.ToString()).Msg("resolved exact hardstate after backup chain sync")
+	return hardstateinfo, nil
+}
+
+func (rs *raftServer) syncBackupChainToClusterTip() error {
+	const (
+		maxSyncTargetWait = 30
+		syncTargetSleep   = time.Second
+	)
+
+	localBest, err := rs.walDB.GetBestBlock()
+	if err != nil {
+		return fmt.Errorf("failed to get local backup best block: %w", err)
+	}
+
+	var (
+		peerID     types.PeerID
+		targetHash []byte
+		targetNo   uint64
+	)
+
+	for i := 0; i < maxSyncTargetWait; i++ {
+		peerID, targetHash, targetNo, err = rs.pickBackupSyncTarget(localBest.BlockNo())
+		if err == nil {
+			break
+		}
+		logger.Warn().Err(err).Int("try", i+1).Msg("waiting for cluster peer tip to sync backup chain")
+		time.Sleep(syncTargetSleep)
+	}
+	if err != nil {
+		return err
+	}
+
+	logger.Info().Str("peer", peerID.Pretty()).Uint64("from", localBest.BlockNo()).Uint64("to", targetNo).
+		Msg("syncing backup chain delta before exact hardstate reset")
+	return conschain.SyncChain(rs.ComponentHub, targetHash, targetNo, peerID)
+}
+
+func (rs *raftServer) pickBackupSyncTarget(localBestNo uint64) (types.PeerID, []byte, uint64, error) {
+	if rs.pa == nil {
+		return "", nil, 0, errors.New("peer accessor is not set for backup chain sync")
+	}
+
+	var (
+		bestPeer types.PeerID
+		bestHash []byte
+		bestNo   uint64
+	)
+
+	for _, info := range rs.pa.GetPeerBlockInfos() {
+		if info == nil || info.State() != types.RUNNING {
+			continue
+		}
+		rs.cluster.Lock()
+		member := rs.cluster.Members().getMemberByPeerID(info.ID())
+		rs.cluster.Unlock()
+		if member == nil {
+			continue
+		}
+		status := info.LastStatus()
+		if status == nil || len(status.BlockHash) == 0 || status.BlockNumber <= localBestNo {
+			continue
+		}
+		if status.BlockNumber > bestNo {
+			bestNo = status.BlockNumber
+			bestHash = append([]byte(nil), status.BlockHash...)
+			bestPeer = info.ID()
+		}
+	}
+
+	if bestNo == 0 {
+		return "", nil, 0, errors.New("no live cluster peer tip ahead of backup chain")
+	}
+	return bestPeer, bestHash, bestNo, nil
 }
 
 func (rs *raftServer) ID() uint64 {

--- a/consensus/impl/raftv2/raftserver.go
+++ b/consensus/impl/raftv2/raftserver.go
@@ -1235,19 +1235,19 @@ func unmarshalConfChangeEntry(entry *raftpb.Entry) (*raftpb.ConfChange, *consens
 	var cc raftpb.ConfChange
 
 	if err := cc.Unmarshal(entry.Data); err != nil {
-		logger.Fatal().Err(err).Uint64("idx", entry.Index).Uint64("term", entry.Term).Msg("failed to unmarshal of conf change entry")
-		return nil, nil, err
+		logger.Error().Err(err).Uint64("idx", entry.Index).Uint64("term", entry.Term).Msg("failed to unmarshal conf change entry")
+		return &raftpb.ConfChange{}, nil, err
 	}
 
 	// skip confChange of empty context
 	if len(cc.Context) == 0 {
-		return nil, nil, nil
+		return &cc, nil, nil
 	}
 
 	var member = consensus.Member{}
 	if err := json.Unmarshal(cc.Context, &member); err != nil {
-		logger.Fatal().Err(err).Uint64("idx", entry.Index).Uint64("term", entry.Term).Msg("failed to unmarshal of context of cc entry")
-		return nil, nil, err
+		logger.Error().Err(err).Uint64("idx", entry.Index).Uint64("term", entry.Term).Msg("failed to unmarshal context of conf change entry")
+		return &cc, nil, err
 	}
 
 	return &cc, &member, nil
@@ -1265,7 +1265,8 @@ func (rs *raftServer) ValidateConfChangeEntry(entry *raftpb.Entry) (*raftpb.Conf
 
 	cc, member, err = unmarshalConfChangeEntry(entry)
 	if err != nil {
-		logger.Fatal().Err(err).Str("entry", entry.String()).Uint64("requestID", cc.ID).Msg("failed to unmarshal conf change")
+		logger.Error().Err(err).Str("entry", entry.String()).Msg("failed to unmarshal conf change")
+		return cc, member, err
 	}
 
 	if alreadyApplied(entry) {

--- a/consensus/impl/raftv2/raftserver.go
+++ b/consensus/impl/raftv2/raftserver.go
@@ -54,15 +54,18 @@ var (
 )
 
 var (
-	ErrRaftNotReady        = errors.New("raft library is not initialized")
-	ErrCCAlreadyApplied    = errors.New("conf change entry is already applied")
-	ErrInvalidMember       = errors.New("member of conf change is invalid")
-	ErrCCAlreadyAdded      = errors.New("member has already added")
-	ErrCCAlreadyRemoved    = errors.New("member has already removed")
-	ErrCCNoMemberToRemove  = errors.New("there is no member to remove")
-	ErrEmptySnapshot       = errors.New("received empty snapshot")
-	ErrInvalidRaftIdentity = errors.New("raft identity is not set")
-	ErrProposeNilBlock     = errors.New("proposed block is nil")
+	ErrRaftNotReady               = errors.New("raft library is not initialized")
+	ErrCCAlreadyApplied           = errors.New("conf change entry is already applied")
+	ErrInvalidMember              = errors.New("member of conf change is invalid")
+	ErrCCAlreadyAdded             = errors.New("member has already added")
+	ErrCCAlreadyRemoved           = errors.New("member has already removed")
+	ErrCCNoMemberToRemove         = errors.New("there is no member to remove")
+	ErrEmptySnapshot              = errors.New("received empty snapshot")
+	ErrInvalidRaftIdentity        = errors.New("raft identity is not set")
+	ErrProposeNilBlock            = errors.New("proposed block is nil")
+	ErrUnknownRaftPeer            = errors.New("raft message sender is not a cluster member")
+	ErrRaftSenderMismatch         = errors.New("raft message sender does not match authenticated peer")
+	ErrRaftTargetMismatch         = errors.New("raft message is addressed to another node")
 )
 
 const (
@@ -1613,7 +1616,26 @@ type raftHttpWrapper struct {
 	raftServer *raftServer
 }
 
+func (rhw *raftHttpWrapper) ValidateMessage(peerID types.PeerID, m raftpb.Message) error {
+	member := rhw.GetMemberByPeerID(peerID)
+	if member == nil {
+		return fmt.Errorf("%w: peer %s", ErrUnknownRaftPeer, peerID)
+	}
+	if m.From != member.ID {
+		return fmt.Errorf("%w: peer %s is raft member %x, message claims %x",
+			ErrRaftSenderMismatch, peerID, member.ID, m.From)
+	}
+	if m.To != rhw.raftServer.ID() {
+		return fmt.Errorf("%w: local %x, message target %x",
+			ErrRaftTargetMismatch, rhw.raftServer.ID(), m.To)
+	}
+	return nil
+}
+
 func (rhw *raftHttpWrapper) Process(ctx context.Context, peerID types.PeerID, m raftpb.Message) error {
+	if err := rhw.ValidateMessage(peerID, m); err != nil {
+		return err
+	}
 	return rhw.raftServer.Process(ctx, m)
 }
 

--- a/consensus/impl/raftv2/raftserver.go
+++ b/consensus/impl/raftv2/raftserver.go
@@ -226,6 +226,7 @@ func makeConfig(nodeID uint64, storage *raftlib.MemoryStorage) *raftlib.Config {
 		MaxInflightMsgs:           256,
 		Logger:                    raftLogger,
 		CheckQuorum:               true,
+		PreVote:                   true,
 		DisableProposalForwarding: true,
 	}
 

--- a/consensus/impl/raftv2/raftserver_security_test.go
+++ b/consensus/impl/raftv2/raftserver_security_test.go
@@ -6,10 +6,17 @@ import (
 
 	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/types"
+	raftlib "github.com/aergoio/etcd/raft"
 	"github.com/aergoio/etcd/raft/raftpb"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
+
+func TestRaftConfigEnablesPreVote(t *testing.T) {
+	if config := makeConfig(1, raftlib.NewMemoryStorage()); !config.PreVote {
+		t.Fatal("raft pre-vote must be enabled to prevent disruptive term inflation after partitions")
+	}
+}
 
 func TestRaftMessagePeerBinding(t *testing.T) {
 	senderPeerID := types.RandomPeerID()

--- a/consensus/impl/raftv2/raftserver_security_test.go
+++ b/consensus/impl/raftv2/raftserver_security_test.go
@@ -132,3 +132,24 @@ func TestRaftBlockSignerMustBeCurrentMember(t *testing.T) {
 		t.Fatal("IsBlockValid() accepted signer outside current membership")
 	}
 }
+
+func TestPublishFirstBlockDoesNotDereferenceEmptyProgress(t *testing.T) {
+	block := types.NewBlock(types.EmptyBlockHeaderInfo, nil, nil, nil, nil, nil)
+	data, err := marshalEntryData(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := &raftServer{
+		commitC: make(chan *commitEntry, 1),
+		stopc:   make(chan struct{}),
+	}
+	if ok := server.publishEntries([]raftpb.Entry{{
+		Index: 1,
+		Term:  1,
+		Type:  raftpb.EntryNormal,
+		Data:  data,
+	}}); !ok {
+		t.Fatal("publishEntries() unexpectedly stopped")
+	}
+}

--- a/consensus/impl/raftv2/raftserver_security_test.go
+++ b/consensus/impl/raftv2/raftserver_security_test.go
@@ -1,0 +1,56 @@
+package raftv2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aergoio/aergo/consensus"
+	"github.com/aergoio/aergo/types"
+	"github.com/aergoio/etcd/raft/raftpb"
+)
+
+func TestRaftMessagePeerBinding(t *testing.T) {
+	senderPeerID := types.RandomPeerID()
+	localPeerID := types.RandomPeerID()
+
+	cluster := NewCluster([]byte("chain"), nil, "local", localPeerID, 0, nil)
+	sender := &consensus.Member{MemberAttr: types.MemberAttr{
+		ID:      11,
+		Name:    "sender",
+		Address: "/ip4/127.0.0.1/tcp/11001",
+		PeerID:  []byte(senderPeerID),
+	}}
+	local := &consensus.Member{MemberAttr: types.MemberAttr{
+		ID:      22,
+		Name:    "local",
+		Address: "/ip4/127.0.0.1/tcp/11002",
+		PeerID:  []byte(localPeerID),
+	}}
+	cluster.Members().add(sender)
+	cluster.Members().add(local)
+	cluster.SetNodeID(local.ID)
+
+	accessor := &raftHttpWrapper{raftServer: &raftServer{cluster: cluster}}
+	valid := raftpb.Message{From: sender.ID, To: local.ID, Type: raftpb.MsgHeartbeat}
+
+	tests := []struct {
+		name   string
+		peerID types.PeerID
+		msg    raftpb.Message
+		want   error
+	}{
+		{name: "valid member", peerID: senderPeerID, msg: valid},
+		{name: "unknown peer", peerID: types.RandomPeerID(), msg: valid, want: ErrUnknownRaftPeer},
+		{name: "spoofed sender", peerID: senderPeerID, msg: raftpb.Message{From: local.ID, To: local.ID, Type: raftpb.MsgHeartbeat}, want: ErrRaftSenderMismatch},
+		{name: "wrong target", peerID: senderPeerID, msg: raftpb.Message{From: sender.ID, To: sender.ID, Type: raftpb.MsgHeartbeat}, want: ErrRaftTargetMismatch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := accessor.ValidateMessage(tt.peerID, tt.msg)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("ValidateMessage() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}

--- a/consensus/impl/raftv2/raftserver_security_test.go
+++ b/consensus/impl/raftv2/raftserver_security_test.go
@@ -54,3 +54,33 @@ func TestRaftMessagePeerBinding(t *testing.T) {
 		})
 	}
 }
+
+func TestSnapshotMembershipMustMatchConfState(t *testing.T) {
+	member := &consensus.Member{MemberAttr: types.MemberAttr{
+		ID:      1,
+		Name:    "member",
+		Address: "/ip4/127.0.0.1/tcp/11001",
+		PeerID:  []byte(types.RandomPeerID()),
+	}}
+	block := types.NewBlock(types.EmptyBlockHeaderInfo, nil, nil, nil, nil, nil)
+	data, err := consensus.NewSnapshotData([]*consensus.Member{member}, nil, block).Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &raftpb.Snapshot{
+		Data: data,
+		Metadata: raftpb.SnapshotMetadata{
+			Index:     1,
+			Term:      1,
+			ConfState: raftpb.ConfState{Nodes: []uint64{member.ID}},
+		},
+	}
+	if err := validateSnapshotConsistency(snapshot); err != nil {
+		t.Fatalf("validateSnapshotConsistency() rejected valid snapshot: %v", err)
+	}
+
+	snapshot.Metadata.ConfState.Nodes[0] = 2
+	if err := validateSnapshotConsistency(snapshot); !errors.Is(err, ErrSnapshotMembershipMismatch) {
+		t.Fatalf("validateSnapshotConsistency() error = %v, want %v", err, ErrSnapshotMembershipMismatch)
+	}
+}

--- a/consensus/impl/raftv2/raftserver_security_test.go
+++ b/consensus/impl/raftv2/raftserver_security_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/types"
 	"github.com/aergoio/etcd/raft/raftpb"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 func TestRaftMessagePeerBinding(t *testing.T) {
@@ -82,5 +84,44 @@ func TestSnapshotMembershipMustMatchConfState(t *testing.T) {
 	snapshot.Metadata.ConfState.Nodes[0] = 2
 	if err := validateSnapshotConsistency(snapshot); !errors.Is(err, ErrSnapshotMembershipMismatch) {
 		t.Fatalf("validateSnapshotConsistency() error = %v, want %v", err, ErrSnapshotMembershipMismatch)
+	}
+}
+
+func TestRaftBlockSignerMustBeCurrentMember(t *testing.T) {
+	memberKey, memberPub, err := crypto.GenerateKeyPair(crypto.Secp256k1, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	memberPeerID, err := peer.IDFromPublicKey(memberPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cluster := NewCluster([]byte("chain"), nil, "local", memberPeerID, 0, nil)
+	cluster.Members().add(&consensus.Member{MemberAttr: types.MemberAttr{
+		ID:      1,
+		Name:    "member",
+		Address: "/ip4/127.0.0.1/tcp/11001",
+		PeerID:  []byte(memberPeerID),
+	}})
+	factory := &BlockFactory{bpc: cluster}
+
+	authorized := types.NewBlock(types.EmptyBlockHeaderInfo, nil, nil, nil, nil, nil)
+	if err := authorized.Sign(memberKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := factory.IsBlockValid(authorized, nil); err != nil {
+		t.Fatalf("IsBlockValid() rejected current member: %v", err)
+	}
+
+	otherKey, _, err := crypto.GenerateKeyPair(crypto.Secp256k1, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthorized := types.NewBlock(types.EmptyBlockHeaderInfo, nil, nil, nil, nil, nil)
+	if err := unauthorized.Sign(otherKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := factory.IsBlockValid(unauthorized, nil); err == nil {
+		t.Fatal("IsBlockValid() accepted signer outside current membership")
 	}
 }

--- a/consensus/impl/raftv2/raftserver_security_test.go
+++ b/consensus/impl/raftv2/raftserver_security_test.go
@@ -64,33 +64,50 @@ func TestRaftMessagePeerBinding(t *testing.T) {
 	}
 }
 
-func TestSnapshotMembershipMustMatchConfState(t *testing.T) {
-	member := &consensus.Member{MemberAttr: types.MemberAttr{
-		ID:      1,
-		Name:    "member",
-		Address: "/ip4/127.0.0.1/tcp/11001",
-		PeerID:  []byte(types.RandomPeerID()),
-	}}
+func TestPublishFirstBlockDoesNotDereferenceEmptyProgress(t *testing.T) {
 	block := types.NewBlock(types.EmptyBlockHeaderInfo, nil, nil, nil, nil, nil)
-	data, err := consensus.NewSnapshotData([]*consensus.Member{member}, nil, block).Encode()
+	data, err := marshalEntryData(block)
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshot := &raftpb.Snapshot{
-		Data: data,
-		Metadata: raftpb.SnapshotMetadata{
-			Index:     1,
-			Term:      1,
-			ConfState: raftpb.ConfState{Nodes: []uint64{member.ID}},
-		},
+
+	server := &raftServer{
+		commitC: make(chan *commitEntry, 1),
+		stopc:   make(chan struct{}),
 	}
-	if err := validateSnapshotConsistency(snapshot); err != nil {
-		t.Fatalf("validateSnapshotConsistency() rejected valid snapshot: %v", err)
+	if ok := server.publishEntries([]raftpb.Entry{{
+		Index: 1,
+		Term:  1,
+		Type:  raftpb.EntryNormal,
+		Data:  data,
+	}}); !ok {
+		t.Fatal("publishEntries() unexpectedly stopped")
+	}
+}
+
+func TestMalformedConfChangeReturnsErrorWithoutPanic(t *testing.T) {
+	server := &raftServer{cluster: NewCluster([]byte("chain"), nil, "local", types.RandomPeerID(), 0, nil)}
+
+	if _, _, err := server.ValidateConfChangeEntry(&raftpb.Entry{
+		Index: 1,
+		Term:  1,
+		Type:  raftpb.EntryConfChange,
+		Data:  []byte{0xff},
+	}); err == nil {
+		t.Fatal("ValidateConfChangeEntry() accepted malformed protobuf")
 	}
 
-	snapshot.Metadata.ConfState.Nodes[0] = 2
-	if err := validateSnapshotConsistency(snapshot); !errors.Is(err, ErrSnapshotMembershipMismatch) {
-		t.Fatalf("validateSnapshotConsistency() error = %v, want %v", err, ErrSnapshotMembershipMismatch)
+	data, err := (&raftpb.ConfChange{NodeID: 1, Type: raftpb.ConfChangeAddNode}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := server.ValidateConfChangeEntry(&raftpb.Entry{
+		Index: 1,
+		Term:  1,
+		Type:  raftpb.EntryConfChange,
+		Data:  data,
+	}); !errors.Is(err, ErrCCMemberIsNil) {
+		t.Fatalf("ValidateConfChangeEntry() error = %v, want %v", err, ErrCCMemberIsNil)
 	}
 }
 
@@ -133,23 +150,32 @@ func TestRaftBlockSignerMustBeCurrentMember(t *testing.T) {
 	}
 }
 
-func TestPublishFirstBlockDoesNotDereferenceEmptyProgress(t *testing.T) {
+func TestSnapshotMembershipMustMatchConfState(t *testing.T) {
+	member := &consensus.Member{MemberAttr: types.MemberAttr{
+		ID:      1,
+		Name:    "member",
+		Address: "/ip4/127.0.0.1/tcp/11001",
+		PeerID:  []byte(types.RandomPeerID()),
+	}}
 	block := types.NewBlock(types.EmptyBlockHeaderInfo, nil, nil, nil, nil, nil)
-	data, err := marshalEntryData(block)
+	data, err := consensus.NewSnapshotData([]*consensus.Member{member}, nil, block).Encode()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	server := &raftServer{
-		commitC: make(chan *commitEntry, 1),
-		stopc:   make(chan struct{}),
+	snapshot := &raftpb.Snapshot{
+		Data: data,
+		Metadata: raftpb.SnapshotMetadata{
+			Index:     1,
+			Term:      1,
+			ConfState: raftpb.ConfState{Nodes: []uint64{member.ID}},
+		},
 	}
-	if ok := server.publishEntries([]raftpb.Entry{{
-		Index: 1,
-		Term:  1,
-		Type:  raftpb.EntryNormal,
-		Data:  data,
-	}}); !ok {
-		t.Fatal("publishEntries() unexpectedly stopped")
+	if err := validateSnapshotConsistency(snapshot); err != nil {
+		t.Fatalf("validateSnapshotConsistency() rejected valid snapshot: %v", err)
+	}
+
+	snapshot.Metadata.ConfState.Nodes[0] = 2
+	if err := validateSnapshotConsistency(snapshot); !errors.Is(err, ErrSnapshotMembershipMismatch) {
+		t.Fatalf("validateSnapshotConsistency() error = %v, want %v", err, ErrSnapshotMembershipMismatch)
 	}
 }

--- a/consensus/impl/raftv2/snapshot.go
+++ b/consensus/impl/raftv2/snapshot.go
@@ -107,7 +107,7 @@ func (chainsnap *ChainSnapshotter) createSnapshotData(cluster *Cluster, snapBloc
 
 // chainSnapshotter rece ives snapshot from http request
 // TODO replace rafthttp with p2p
-func (chainsnap *ChainSnapshotter) SaveFromRemote(r io.Reader, id uint64, msg raftpb.Message) (int64, error) {
+func (chainsnap *ChainSnapshotter) SaveFromRemote(r io.Reader, senderID uint64, msg raftpb.Message) (int64, error) {
 	defer RecoverExit()
 
 	if msg.Type != raftpb.MsgSnap {
@@ -117,10 +117,10 @@ func (chainsnap *ChainSnapshotter) SaveFromRemote(r io.Reader, id uint64, msg ra
 
 	// not return until block sync is complete
 	// receive chain & request sync & wait
-	return 0, chainsnap.syncSnap(&msg.Snapshot)
+	return 0, chainsnap.syncSnap(&msg.Snapshot, senderID)
 }
 
-func (chainsnap *ChainSnapshotter) syncSnap(snap *raftpb.Snapshot) error {
+func (chainsnap *ChainSnapshotter) syncSnap(snap *raftpb.Snapshot, senderID uint64) error {
 	var snapdata = &consensus.SnapshotData{}
 
 	err := snapdata.Decode(snap.Data)
@@ -133,7 +133,7 @@ func (chainsnap *ChainSnapshotter) syncSnap(snap *raftpb.Snapshot) error {
 	logger.Info().Str("snap", consensus.SnapToString(snap, snapdata)).Msg("start to sync snapshot")
 	// TODO	request sync for chain with snapshot.data
 	// wait to finish sync of chain
-	if err := chainsnap.requestSync(&snapdata.Chain); err != nil {
+	if err := chainsnap.requestSync(&snapdata.Chain, senderID); err != nil {
 		logger.Error().Err(err).Msg("failed to sync snapshot")
 		return err
 	}
@@ -153,12 +153,19 @@ func (chainsnap *ChainSnapshotter) checkPeerLive(peerID types.PeerID) bool {
 }
 
 // TODO handle error case that leader stops while synchronizing
-func (chainsnap *ChainSnapshotter) requestSync(snap *consensus.ChainSnapshot) error {
+func (chainsnap *ChainSnapshotter) requestSync(snap *consensus.ChainSnapshot, senderID uint64) error {
 
 	var leader uint64
 	getSyncLeader := func() (types.PeerID, error) {
 		var peerID types.PeerID
 		var err error
+
+		if senderID != HasNoLeader {
+			if peerID, err = chainsnap.cluster.getMemberPeerAddress(senderID); err == nil &&
+				chainsnap.checkPeerLive(peerID) {
+				return peerID, nil
+			}
+		}
 
 		for {
 			leader = chainsnap.getLeaderFunc()
@@ -170,7 +177,7 @@ func (chainsnap *ChainSnapshotter) requestSync(snap *consensus.ChainSnapshot) er
 					return "", err
 				}
 			} else {
-				peerID, err = chainsnap.cluster.Members().getMemberPeerAddress(leader)
+				peerID, err = chainsnap.cluster.getMemberPeerAddress(leader)
 				if err != nil {
 					logger.Error().Err(err).Str("leader", EtcdIDToString(leader)).Msg("can't get peeraddress of leader")
 					return "", err

--- a/consensus/raftCommon.go
+++ b/consensus/raftCommon.go
@@ -385,6 +385,10 @@ type DummyRaftAccessor struct {
 
 var IllegalArgumentError = errors.New("illegal argument")
 
+func (DummyRaftAccessor) ValidateMessage(peerID types.PeerID, m raftpb.Message) error {
+	return IllegalArgumentError
+}
+
 func (DummyRaftAccessor) Process(ctx context.Context, peerID types.PeerID, m raftpb.Message) error {
 	return IllegalArgumentError
 }

--- a/consensus/raftCommon.go
+++ b/consensus/raftCommon.go
@@ -325,6 +325,11 @@ func (m *Member) IsValid() bool {
 		return false
 	}
 
+	if _, err := types.IDFromBytes(m.PeerID); err != nil {
+		logger.Error().Err(err).Msg("parse peer ID of member")
+		return false
+	}
+
 	if _, err := types.ParseMultiaddr(m.Address); err != nil {
 		logger.Error().Err(err).Msg("parse address of member")
 		return false

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/aergoio/aergo-actor v0.0.0-20190219030625-562037d5fec7
-	github.com/aergoio/aergo-lib v1.1.3-0.20260429030355-b6d239f4cb10
+	github.com/aergoio/aergo-lib v1.1.3-0.20260808042159-3923a46f5137
 	github.com/aergoio/etcd v0.0.0-20190429013412-e8b3f96f6399
 	github.com/anaskhan96/base58check v0.0.0-20181220122047-b05365d494c4
 	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798 // indirect
 	github.com/Shopify/sarama v1.22.1 // indirect
 	github.com/Workiva/go-datastructures v1.0.50 // indirect
-	github.com/aergoio/hashtabledb v0.0.0-20251017201446-c5c26be07a6e // indirect
+	github.com/aergoio/hashtabledb v0.0.0-20260808040708-13b4f29bcc3b // indirect
 	github.com/apache/thrift v0.12.0 // indirect
 	github.com/beorn7/perks v1.0.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,12 +17,12 @@ github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/aergoio/aergo-actor v0.0.0-20190219030625-562037d5fec7 h1:dYRi21hTS3fJwjSh/KZTAuLXUbV/Ijm2395Nf4b3wNs=
 github.com/aergoio/aergo-actor v0.0.0-20190219030625-562037d5fec7/go.mod h1:/nqZcvcM0UipJRnUm61LrQ8rC7IyBr8mfx5F00sCbvs=
-github.com/aergoio/aergo-lib v1.1.3-0.20260429030355-b6d239f4cb10 h1:413G+W3dhsWI+6xpnflB+xO1xIpzRsXiNLskVyIktmw=
-github.com/aergoio/aergo-lib v1.1.3-0.20260429030355-b6d239f4cb10/go.mod h1:hQoKU2HUFhO4ijPdyTuOFFmR6AroyqgCnQ5vmCtbcfk=
+github.com/aergoio/aergo-lib v1.1.3-0.20260808042159-3923a46f5137 h1:/mXKmmr7HWg3O0ogzsBVtn7Qn6OHTVzjmsnjtSKNG+I=
+github.com/aergoio/aergo-lib v1.1.3-0.20260808042159-3923a46f5137/go.mod h1:PKQvNfY/HTUJUgd8JWhKaAUcCKtS8/4ejuG390KRfpE=
 github.com/aergoio/etcd v0.0.0-20190429013412-e8b3f96f6399 h1:dJSTOiNe0xJFreGUBSh4bY3KGDxjilUVxAKqjij1pcw=
 github.com/aergoio/etcd v0.0.0-20190429013412-e8b3f96f6399/go.mod h1:Blp9ztau8P3FoDynvGUeKUD6qqW/2xQ80kNwU+ywPUM=
-github.com/aergoio/hashtabledb v0.0.0-20251017201446-c5c26be07a6e h1:KrH9uB1gzev/HtNZjWVSS5k85nXeHZKR1za44uQy9PI=
-github.com/aergoio/hashtabledb v0.0.0-20251017201446-c5c26be07a6e/go.mod h1:IqGin7i9MiVvVI1TnRSvtgxQygS9qIltYpT8VZaoT/w=
+github.com/aergoio/hashtabledb v0.0.0-20260808040708-13b4f29bcc3b h1:/aisBUH/P7PgkovhMzryja6DEv1idaHqKrPqK8JUJQI=
+github.com/aergoio/hashtabledb v0.0.0-20260808040708-13b4f29bcc3b/go.mod h1:IqGin7i9MiVvVI1TnRSvtgxQygS9qIltYpT8VZaoT/w=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anaskhan96/base58check v0.0.0-20181220122047-b05365d494c4 h1:FUDNaUiPOxrVtUmsRSdx7hrvCKXpfQafPpPU0Yh27os=

--- a/message/syncermsg.go
+++ b/message/syncermsg.go
@@ -1,10 +1,17 @@
 package message
 
 import (
+	"errors"
+
 	"github.com/aergoio/aergo/types"
 )
 
 const SyncerSvc = "SyncerSvc"
+
+// ErrSyncerBusy is returned (via NotifyC) when SyncStart is requested while a
+// sync is already in progress. Callers should wait/retry rather than treating
+// this as a fatal sync failure.
+var ErrSyncerBusy = errors.New("syncer is already running")
 
 //Syncer
 type SyncStart struct {

--- a/p2p/p2pmock/mock_consensus.go
+++ b/p2p/p2pmock/mock_consensus.go
@@ -176,6 +176,20 @@ func (mr *MockAergoRaftAccessorMockRecorder) IsIDRemoved(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIDRemoved", reflect.TypeOf((*MockAergoRaftAccessor)(nil).IsIDRemoved), arg0)
 }
 
+// ValidateMessage mocks base method
+func (m *MockAergoRaftAccessor) ValidateMessage(arg0 peer.ID, arg1 raftpb.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateMessage", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateMessage indicates an expected call of ValidateMessage
+func (mr *MockAergoRaftAccessorMockRecorder) ValidateMessage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateMessage", reflect.TypeOf((*MockAergoRaftAccessor)(nil).ValidateMessage), arg0, arg1)
+}
+
 // Process mocks base method
 func (m *MockAergoRaftAccessor) Process(arg0 context.Context, arg1 peer.ID, arg2 raftpb.Message) error {
 	m.ctrl.T.Helper()

--- a/p2p/p2pmock/mock_peermanager.go
+++ b/p2p/p2pmock/mock_peermanager.go
@@ -273,3 +273,17 @@ func (mr *MockPeerManagerMockRecorder) ListDesignatedPeers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDesignatedPeers", reflect.TypeOf((*MockPeerManager)(nil).ListDesignatedPeers))
 }
+
+// MsgBufSize mocks base method
+func (m *MockPeerManager) MsgBufSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MsgBufSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// MsgBufSize indicates an expected call of MsgBufSize
+func (mr *MockPeerManagerMockRecorder) MsgBufSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MsgBufSize", reflect.TypeOf((*MockPeerManager)(nil).MsgBufSize))
+}

--- a/p2p/raftsupport/concclusterreceiver.go
+++ b/p2p/raftsupport/concclusterreceiver.go
@@ -6,9 +6,12 @@
 package raftsupport
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"github.com/aergoio/aergo-lib/log"
 	"github.com/aergoio/aergo/p2p/p2putil"
 	"github.com/pkg/errors"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -83,7 +86,7 @@ func (r *ConcurrentClusterInfoReceiver) runExpireTimer() {
 }
 
 func (r *ConcurrentClusterInfoReceiver) trySendAllPeers() bool {
-	r.logger.Debug().Array("peers", p2putil.NewLogPeersMarshaller(r.peers,10)).Msg("sending get cluster request to connected peers")
+	r.logger.Debug().Array("peers", p2putil.NewLogPeersMarshaller(r.peers, 10)).Msg("sending get cluster request to connected peers")
 	req := &types.GetClusterInfoRequest{BestBlockHash: r.req.BestBlockHash}
 	for _, peer := range r.peers {
 		if peer.State() == types.RUNNING {
@@ -196,6 +199,63 @@ func (r *ConcurrentClusterInfoReceiver) ignoreMsg(msg p2pcommon.Message, msgBody
 	// nothing to do for now
 }
 
+func clusterConfigFingerprint(resp *types.GetClusterInfoResponse) ([sha256.Size]byte, error) {
+	type canonicalMember struct {
+		ID      uint64
+		Name    string
+		Address string
+		PeerID  []byte
+	}
+	type canonicalCluster struct {
+		ChainID      []byte
+		ClusterID    uint64
+		Members      []canonicalMember
+		HasHardState bool
+		Term         uint64
+		Commit       uint64
+	}
+
+	cluster := canonicalCluster{
+		ChainID:   resp.ChainID,
+		ClusterID: resp.ClusterID,
+		Members:   make([]canonicalMember, len(resp.MbrAttrs)),
+	}
+	if resp.HardStateInfo != nil {
+		cluster.HasHardState = true
+		cluster.Term = resp.HardStateInfo.Term
+		cluster.Commit = resp.HardStateInfo.Commit
+	}
+	for i, member := range resp.MbrAttrs {
+		if member == nil {
+			return [sha256.Size]byte{}, errors.New("nil member in cluster response")
+		}
+		cluster.Members[i] = canonicalMember{
+			ID:      member.ID,
+			Name:    member.Name,
+			Address: member.Address,
+			PeerID:  member.PeerID,
+		}
+	}
+	sort.Slice(cluster.Members, func(i, j int) bool {
+		if cluster.Members[i].ID != cluster.Members[j].ID {
+			return cluster.Members[i].ID < cluster.Members[j].ID
+		}
+		if cluster.Members[i].Name != cluster.Members[j].Name {
+			return cluster.Members[i].Name < cluster.Members[j].Name
+		}
+		if cluster.Members[i].Address != cluster.Members[j].Address {
+			return cluster.Members[i].Address < cluster.Members[j].Address
+		}
+		return string(cluster.Members[i].PeerID) < string(cluster.Members[j].PeerID)
+	})
+
+	encoded, err := json.Marshal(cluster)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(encoded), nil
+}
+
 func (r *ConcurrentClusterInfoReceiver) calculate(err error) *message.GetClusterRsp {
 	rsp := &message.GetClusterRsp{}
 	if err != nil {
@@ -204,23 +264,37 @@ func (r *ConcurrentClusterInfoReceiver) calculate(err error) *message.GetCluster
 		rsp.Err = errors.New("too low responses: " + strconv.Itoa(len(r.succResps)))
 	} else {
 		r.logger.Debug().Int("respCnt", len(r.succResps)).Msg("calculating collected responses")
-		var bestRsp *types.GetClusterInfoResponse = nil
-		var bestPid types.PeerID
+		groups := make(map[[sha256.Size]byte][]*types.GetClusterInfoResponse)
 		for pid, rsp := range r.succResps {
-			if bestRsp == nil || rsp.BestBlockNo > bestRsp.BestBlockNo {
-				bestRsp = rsp
-				bestPid = pid
+			fingerprint, err := clusterConfigFingerprint(rsp)
+			if err != nil {
+				r.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(pid)).Err(err).Msg("ignored invalid cluster response")
+				continue
+			}
+			groups[fingerprint] = append(groups[fingerprint], rsp)
+		}
+
+		var agreeing []*types.GetClusterInfoResponse
+		for _, group := range groups {
+			if len(group) > len(agreeing) {
+				agreeing = group
 			}
 		}
-		if bestRsp != nil {
-			r.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(bestPid)).Object("resp", bestRsp).Msg("chosed best response")
-			rsp.ClusterID = bestRsp.GetClusterID()
-			rsp.ChainID = bestRsp.GetChainID()
-			rsp.Members = bestRsp.GetMbrAttrs()
-			rsp.HardStateInfo = bestRsp.HardStateInfo
-		} else {
-			rsp.Err = errors.New("no successful responses")
+		if len(agreeing) < r.requiredResp {
+			rsp.Err = errors.New("too few peers agree on cluster configuration and checkpoint")
+			return rsp
 		}
+
+		selected := agreeing[0]
+		for _, candidate := range agreeing[1:] {
+			if candidate.BestBlockNo > selected.BestBlockNo {
+				selected = candidate
+			}
+		}
+		rsp.ClusterID = selected.GetClusterID()
+		rsp.ChainID = selected.GetChainID()
+		rsp.Members = selected.GetMbrAttrs()
+		rsp.HardStateInfo = selected.HardStateInfo
 	}
 	return rsp
 }

--- a/p2p/raftsupport/concclusterreceiver_test.go
+++ b/p2p/raftsupport/concclusterreceiver_test.go
@@ -156,6 +156,9 @@ func TestConcurrentClusterInfoReceiver_ReceiveResp(t *testing.T) {
 
 	sampleChainID := []byte("testChain")
 	members := make([]*types.MemberAttr, 4)
+	for i := range members {
+		members[i] = &types.MemberAttr{ID: uint64(i + 1), Name: "member"}
+	}
 
 	type args struct {
 		retStats []retStat
@@ -164,16 +167,16 @@ func TestConcurrentClusterInfoReceiver_ReceiveResp(t *testing.T) {
 		name string
 		args args
 
-		wantBestNo int  // count of sent to remote peers
+		wantBestNo  int  // count of sent to remote peers
 		wantErrResp bool // result with error or not
 	}{
 		{"TAllSame", args{[]retStat{10, 10, 10, 10, 10}}, 10, false},
-		{"TErrRet", args{ []retStat{ERR,ERR,ERR,ERR,ERR}}, 10,  true},
-		{"TMixed", args{ []retStat{100, ERR, 99, 98, ERR}}, 100,  false},
-		{"TMixed2", args{ []retStat{100, ERR, NOR, ERR, 100}}, 100,  true},
-		{"TTimeSucc", args{ []retStat{NOR, 99, NOR, 98, 99}}, 99,  false},
-		{"TTime1", args{ []retStat{NOR, ERR, NOR, 100, 100}}, 100,  true},
-		{"TTime2", args{ []retStat{NOR, NOR, NOR, 100, 100}}, 100,  true},
+		{"TErrRet", args{[]retStat{ERR, ERR, ERR, ERR, ERR}}, 10, true},
+		{"TMixed", args{[]retStat{100, ERR, 99, 98, ERR}}, 100, false},
+		{"TMixed2", args{[]retStat{100, ERR, NOR, ERR, 100}}, 100, true},
+		{"TTimeSucc", args{[]retStat{NOR, 99, NOR, 98, 99}}, 99, false},
+		{"TTime1", args{[]retStat{NOR, ERR, NOR, 100, 100}}, 100, true},
+		{"TTime2", args{[]retStat{NOR, NOR, NOR, 100, 100}}, 100, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -205,7 +208,8 @@ func TestConcurrentClusterInfoReceiver_ReceiveResp(t *testing.T) {
 				mockPeer.EXPECT().Name().Return("peer" + p2putil.ShortForm(dummyPeerID)).AnyTimes()
 				mockPeer.EXPECT().ConsumeRequest(gomock.Any()).AnyTimes()
 				mockPeer.EXPECT().SendMessage(mockMO).Do(func(arg interface{}) {
-					atomic.StoreInt32(&sentTrigger, 1)})
+					atomic.StoreInt32(&sentTrigger, 1)
+				})
 				peers[i] = mockPeer
 				sMap[msgID] = mockPeer
 
@@ -229,8 +233,8 @@ func TestConcurrentClusterInfoReceiver_ReceiveResp(t *testing.T) {
 					rBodies = append(rBodies, body)
 				}
 			}
-			ttl := time.Second>>4
-			target := NewConcClusterInfoReceiver(mockActor, mockMF, peers, ttl , dummyReq, logger)
+			ttl := time.Second >> 4
+			target := NewConcClusterInfoReceiver(mockActor, mockMF, peers, ttl, dummyReq, logger)
 			target.StartGet()
 
 			wg := sync.WaitGroup{}
@@ -270,5 +274,87 @@ func TestConcurrentClusterInfoReceiver_ReceiveResp(t *testing.T) {
 
 			ctrl.Finish()
 		})
+	}
+}
+
+func TestConcurrentClusterInfoReceiverRequiresConfigurationAgreement(t *testing.T) {
+	logger := log.NewLogger("raft.support.test")
+	member := &types.MemberAttr{ID: 1, Name: "member", Address: "/ip4/127.0.0.1/tcp/11001", PeerID: []byte("peer")}
+	honest := func(commit, best uint64) *types.GetClusterInfoResponse {
+		return &types.GetClusterInfoResponse{
+			ChainID:       []byte("chain"),
+			ClusterID:     7,
+			MbrAttrs:      []*types.MemberAttr{member},
+			BestBlockNo:   best,
+			HardStateInfo: &types.HardStateInfo{Term: 2, Commit: commit},
+		}
+	}
+	malicious := honest(1<<60, 1<<60)
+	malicious.ClusterID = 999
+
+	receiver := &ConcurrentClusterInfoReceiver{
+		logger:       logger,
+		requiredResp: 2,
+		succResps: map[types.PeerID]*types.GetClusterInfoResponse{
+			types.RandomPeerID(): honest(11, 10),
+			types.RandomPeerID(): honest(11, 11),
+			types.RandomPeerID(): honest(11, 12),
+			types.RandomPeerID(): malicious,
+		},
+	}
+
+	result := receiver.calculate(nil)
+	if result.Err != nil {
+		t.Fatalf("calculate() error = %v", result.Err)
+	}
+	if result.ClusterID != 7 || result.HardStateInfo.Commit != 11 {
+		t.Fatalf("calculate() selected cluster %d commit %d, want cluster 7 commit 11",
+			result.ClusterID, result.HardStateInfo.Commit)
+	}
+}
+
+func TestConcurrentClusterInfoReceiverRejectsSplitConfiguration(t *testing.T) {
+	logger := log.NewLogger("raft.support.test")
+	response := func(clusterID uint64) *types.GetClusterInfoResponse {
+		return &types.GetClusterInfoResponse{
+			ChainID:   []byte("chain"),
+			ClusterID: clusterID,
+			MbrAttrs:  []*types.MemberAttr{{ID: clusterID, Name: "member"}},
+		}
+	}
+	receiver := &ConcurrentClusterInfoReceiver{
+		logger:       logger,
+		requiredResp: 2,
+		succResps: map[types.PeerID]*types.GetClusterInfoResponse{
+			types.RandomPeerID(): response(1),
+			types.RandomPeerID(): response(2),
+		},
+	}
+
+	if result := receiver.calculate(nil); result.Err == nil {
+		t.Fatal("calculate() accepted responses that disagree on cluster configuration")
+	}
+}
+
+func TestConcurrentClusterInfoReceiverRejectsSplitCheckpoint(t *testing.T) {
+	response := func(commit uint64) *types.GetClusterInfoResponse {
+		return &types.GetClusterInfoResponse{
+			ChainID:       []byte("chain"),
+			ClusterID:     1,
+			MbrAttrs:      []*types.MemberAttr{{ID: 1, Name: "member"}},
+			HardStateInfo: &types.HardStateInfo{Term: 1, Commit: commit},
+		}
+	}
+	receiver := &ConcurrentClusterInfoReceiver{
+		logger:       log.NewLogger("raft.support.test"),
+		requiredResp: 2,
+		succResps: map[types.PeerID]*types.GetClusterInfoResponse{
+			types.RandomPeerID(): response(10),
+			types.RandomPeerID(): response(11),
+		},
+	}
+
+	if result := receiver.calculate(nil); result.Err == nil {
+		t.Fatal("calculate() accepted responses that disagree on raft checkpoint")
 	}
 }

--- a/p2p/raftsupport/rafttransport.go
+++ b/p2p/raftsupport/rafttransport.go
@@ -33,6 +33,7 @@ var (
 	errRemovedMember     = errors.New("member was removed")
 	errUnreachableMember = errors.New("member is unreachable")
 )
+
 // AergoRaftTransport is wrapper of p2p module
 type AergoRaftTransport struct {
 	logger *log.Logger
@@ -48,8 +49,9 @@ type AergoRaftTransport struct {
 	cluster *raftv2.Cluster
 
 	// statuses have connection status of memeber peers
-	statuses map[rtypes.ID]*rPeerStatus
-	stByPID  map[types.PeerID]*rPeerStatus
+	statuses         map[rtypes.ID]*rPeerStatus
+	stByPID          map[types.PeerID]*rPeerStatus
+	snapshotReceiveC chan struct{}
 
 	// copied from original transport
 	ServerStats *stats.ServerStats
@@ -60,9 +62,10 @@ var _ raftv2.Transporter = (*AergoRaftTransport)(nil)
 
 func NewAergoRaftTransport(logger *log.Logger, nt p2pcommon.NetworkTransport, pm p2pcommon.PeerManager, mf p2pcommon.MoFactory, consAcc consensus.ConsensusAccessor, cluster interface{}) *AergoRaftTransport {
 	t := &AergoRaftTransport{logger: logger, nt: nt, pm: pm, mf: mf, consAcc: consAcc, raftAcc: consAcc.RaftAccessor(), cluster: cluster.(*raftv2.Cluster),
-		statuses:    make(map[rtypes.ID]*rPeerStatus),
-		stByPID:     make(map[types.PeerID]*rPeerStatus),
-		ServerStats: stats.NewServerStats("", ""),
+		statuses:         make(map[rtypes.ID]*rPeerStatus),
+		stByPID:          make(map[types.PeerID]*rPeerStatus),
+		snapshotReceiveC: make(chan struct{}, 1),
+		ServerStats:      stats.NewServerStats("", ""),
 	}
 	// TODO need check real id type
 	t.LeaderStats = stats.NewLeaderStats(strconv.Itoa(int(t.cluster.NodeID())))
@@ -108,7 +111,6 @@ func (t *AergoRaftTransport) Send(msgs []raftpb.Message) {
 			continue
 		}
 
-		t.logger.Debug().Str(p2putil.LogPeerID, p2putil.ShortForm(member.GetPeerID())).Object("raftMsg", &RaftMsgMarshaller{&m}).Msg("can't send message to unconnected peer")
 	}
 }
 
@@ -252,6 +254,24 @@ func (t *AergoRaftTransport) OnRaftSnapshot(s network.Stream) {
 		s.Close()
 		return
 	}
+	if t.raftAcc.GetMemberByPeerID(peerID) == nil {
+		t.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("rejecting snapshot stream from non-member peer")
+		hsresp.RespCode = p2pcommon.HSCodeNoPermission
+		s.Write(hsresp.Marshal())
+		s.Close()
+		return
+	}
+	select {
+	case t.snapshotReceiveC <- struct{}{}:
+		defer func() { <-t.snapshotReceiveC }()
+	default:
+		t.logger.Warn().Str(p2putil.LogPeerID, p2putil.ShortForm(peerID)).Msg("rejecting concurrent snapshot stream")
+		hsresp.RespCode = p2pcommon.HSCodeInvalidState
+		s.Write(hsresp.Marshal())
+		s.Close()
+		return
+	}
+	_ = s.SetReadDeadline(time.Now().Add(30 * time.Second))
 	//// TODO raft role is not properly set yet.
 	//if peer.AcceptedRole() != p2pcommon.RaftLeader {
 	//	t.logger.Warn().Str(p2putil.LogPeerName, peer.Name()).Msg("Closing snapshot stream from follower node")

--- a/p2p/raftsupport/snapshotreceiver.go
+++ b/p2p/raftsupport/snapshotreceiver.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	SnapRespHeaderLength = 4
+	SnapRespHeaderLength       = 4
+	maxSnapshotRaftMessageSize = 16 * 1024 * 1024
 )
+
 // TODO consider the scope of type
 type snapshotReceiver struct {
 	logger *log.Logger
@@ -35,15 +37,15 @@ func newSnapshotReceiver(logger *log.Logger, pm p2pcommon.PeerManager, rAcc cons
 	return &snapshotReceiver{logger: logger, pm: pm, rAcc: rAcc, peer: peer, rwc: sender}
 }
 
-
 func (s *snapshotReceiver) Receive() {
-	resp := &types.SnapshotResponse{Status:types.ResultStatus_OK}
+	resp := &types.SnapshotResponse{Status: types.ResultStatus_OK}
 	defer s.sendResp(s.rwc, resp)
 
 	dec := &RaftMsgDecoder{r: s.rwc}
-	// let snapshots be very large since they can exceed 512MB for large installations
-	m, err := dec.DecodeLimit(uint64(1 << 63))
-	from := rtypes.ID(m.From).String()
+	// Only the raft message envelope is decoded here. The potentially large
+	// database snapshot follows as a stream and must not influence this
+	// allocation limit.
+	m, err := dec.DecodeLimit(maxSnapshotRaftMessageSize)
 	if err != nil {
 		s.logger.Error().Str(p2putil.LogPeerName, s.peer.Name()).Err(err).Msg("failed to decode raft message")
 		resp.Status = types.ResultStatus_INVALID_ARGUMENT
@@ -54,6 +56,7 @@ func (s *snapshotReceiver) Receive() {
 		return
 	}
 
+	from := rtypes.ID(m.From).String()
 	//receivedBytes.WithLabelValues(from).Add(float64(m.Size()))
 
 	if m.Type != raftpb.MsgSnap {
@@ -66,9 +69,16 @@ func (s *snapshotReceiver) Receive() {
 		return
 	}
 
+	if err := s.rAcc.ValidateMessage(s.peer.ID(), m); err != nil {
+		s.logger.Warn().Str(p2putil.LogPeerName, s.peer.Name()).Err(err).Msg("rejected snapshot from unauthorized raft sender")
+		resp.Status = types.ResultStatus_PERMISSION_DENIED
+		resp.Message = "unauthorized raft sender"
+		return
+	}
+
 	s.logger.Info().Uint64("index", m.Snapshot.Metadata.Index).Str("from", from).Msg("receiving database snapshot")
 	// save incoming database snapshot.
-	_, err = s.rAcc.SaveFromRemote(s.rwc, m.Snapshot.Metadata.Index, m)
+	_, err = s.rAcc.SaveFromRemote(s.rwc, m.From, m)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to save KV snapshot")
 		resp.Status = types.ResultStatus_INTERNAL
@@ -80,13 +90,13 @@ func (s *snapshotReceiver) Receive() {
 	//receivedBytes.WithLabelValues(from).Add(float64(n))
 	s.logger.Info().Str(p2putil.LogPeerName, s.peer.Name()).Uint64("index", m.Snapshot.Metadata.Index).Str("from", from).Msg("received and saved database snapshot successfully")
 
-	if err := s.rAcc.Process(context.TODO(),s.peer.ID(), m); err != nil {
+	if err := s.rAcc.Process(context.TODO(), s.peer.ID(), m); err != nil {
 		switch v := err.(type) {
 		// Process may return codeError error when doing some
 		// additional checks before calling raft.Node.Step.
 		case codeError:
 			// TODO get resp
-			resp.Status =v.Status()
+			resp.Status = v.Status()
 			resp.Message = v.Message()
 		default:
 			s.logger.Warn().Err(err).Msg("failed to process raft message")

--- a/p2p/raftsupport/snapshotreceiver_test.go
+++ b/p2p/raftsupport/snapshotreceiver_test.go
@@ -7,6 +7,7 @@ package raftsupport
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/aergoio/aergo-lib/log"
@@ -19,12 +20,12 @@ func TestSnapshotReceiver_sendResp(t *testing.T) {
 		resp *types.SnapshotResponse
 	}
 	tests := []struct {
-		name   string
-		args   args
+		name string
+		args args
 	}{
-		{"TOK",args{&types.SnapshotResponse{Status:types.ResultStatus_OK,}}},
-		{"TWrongHead",args{&types.SnapshotResponse{Status:types.ResultStatus_INVALID_ARGUMENT,Message:"wrong type"}}},
-		{"TInternal",args{&types.SnapshotResponse{Status:types.ResultStatus_INTERNAL,Message:""}}},
+		{"TOK", args{&types.SnapshotResponse{Status: types.ResultStatus_OK}}},
+		{"TWrongHead", args{&types.SnapshotResponse{Status: types.ResultStatus_INVALID_ARGUMENT, Message: "wrong type"}}},
+		{"TInternal", args{&types.SnapshotResponse{Status: types.ResultStatus_INTERNAL, Message: ""}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -43,11 +44,23 @@ func TestSnapshotReceiver_sendResp(t *testing.T) {
 				t.Fatalf("readWireHSResp() err %v, want no error ", err.Error())
 			}
 			if tt.args.resp.Status != resp.Status {
-				t.Fatalf("Response status %v, want %v",resp.Status.String(), tt.args.resp.Status.String() )
+				t.Fatalf("Response status %v, want %v", resp.Status.String(), tt.args.resp.Status.String())
 			}
 			if tt.args.resp.Message != resp.Message {
-				t.Fatalf("Response message %v, want %v",resp.Message, tt.args.resp.Message )
+				t.Fatalf("Response message %v, want %v", resp.Message, tt.args.resp.Message)
 			}
 		})
+	}
+}
+
+func TestSnapshotReceiverRejectsOversizedRaftEnvelope(t *testing.T) {
+	var wire bytes.Buffer
+	if err := binary.Write(&wire, binary.BigEndian, uint64(maxSnapshotRaftMessageSize+1)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (&RaftMsgDecoder{r: &wire}).DecodeLimit(maxSnapshotRaftMessageSize)
+	if err != ErrExceedSizeLimit {
+		t.Fatalf("DecodeLimit() error = %v, want %v", err, ErrExceedSizeLimit)
 	}
 }

--- a/p2p/raftsupport/snapshotsender.go
+++ b/p2p/raftsupport/snapshotsender.go
@@ -100,20 +100,18 @@ func (s *snapshotSender) pushBMsg(body io.Reader, to io.ReadWriteCloser) error {
 		ProcessingLimit = time.Minute * 20    // receiving peer should complete and response within after receiving whole snapshot data.
 	)
 
-	wErr := make(chan error, 1)
+	wResult := make(chan error, 1)
 	rResult := make(chan error, 1)
 	t := time.NewTimer(WholeTimeLimit)
 	// write snapshot bytes
 	go func() {
 		_, err := io.Copy(to, body)
-		if err != nil {
-			wErr <- err
-		}
 		// renew timer if timer is not expired yet.
 		if !t.Stop() {
 			<-t.C
 		}
 		t.Reset(ProcessingLimit)
+		wResult <- err
 	}()
 
 	// read response of receiver
@@ -129,15 +127,38 @@ func (s *snapshotSender) pushBMsg(body io.Reader, to io.ReadWriteCloser) error {
 		rResult <- err
 	}()
 
-	select {
-	case <-s.stopChan:
-		return errors.New("stopped")
-	case <-t.C:
-		return errors.New("timeout")
-	case r := <-wErr:
-		return r
-	case r := <-rResult:
-		return r
+	var writeErr error
+	writeDone := false
+	for {
+		select {
+		case <-s.stopChan:
+			to.Close()
+			if !writeDone {
+				<-wResult
+			}
+			return errors.New("stopped")
+		case <-t.C:
+			to.Close()
+			if !writeDone {
+				<-wResult
+			}
+			return errors.New("timeout")
+		case writeErr = <-wResult:
+			writeDone = true
+			wResult = nil
+			if writeErr != nil {
+				return writeErr
+			}
+		case readErr := <-rResult:
+			if !writeDone {
+				writeErr = <-wResult
+				writeDone = true
+			}
+			if writeErr != nil {
+				return writeErr
+			}
+			return readErr
+		}
 	}
 }
 

--- a/p2p/raftsupport/snapshotsender.go
+++ b/p2p/raftsupport/snapshotsender.go
@@ -34,8 +34,10 @@ type snapshotSender struct {
 	peer p2pcommon.RemotePeer
 }
 
+const maxSnapshotResponseSize = 64 * 1024
+
 func newSnapshotSender(logger *log.Logger, nt p2pcommon.NetworkTransport, rAcc consensus.AergoRaftAccessor, peer p2pcommon.RemotePeer) *snapshotSender {
-	return &snapshotSender{logger: logger, nt: nt, rAcc: rAcc, stopChan: make(chan interface{}), peer:peer}
+	return &snapshotSender{logger: logger, nt: nt, rAcc: rAcc, stopChan: make(chan interface{}), peer: peer}
 }
 
 func (s *snapshotSender) Send(snapMsg *snap.Message) {
@@ -160,6 +162,9 @@ func readWireHSResp(rd io.Reader) (resp types.SnapshotResponse, err error) {
 	}
 
 	respLen := binary.BigEndian.Uint32(bytebuf)
+	if respLen > maxSnapshotResponseSize {
+		return resp, ErrExceedSizeLimit
+	}
 	bodyBuf := make([]byte, respLen)
 	readn, err = p2putil.ReadToLen(rd, bodyBuf)
 	if err != nil {

--- a/p2p/raftsupport/snapshotsender_test.go
+++ b/p2p/raftsupport/snapshotsender_test.go
@@ -102,6 +102,7 @@ func Test_readWireHSResp(t *testing.T) {
 		{"TLongBody", append(CopyOf(sample), []byte("dummies")...), false},
 		{"TShortBody", CopyOf(sample)[:len(sample)-1], true},
 		{"TWrongHead", CopyOf(sample)[:3], true},
+		{"TOversizedBody", []byte{0x00, 0x01, 0x00, 0x01}, true},
 		//		{"TInvalidByte", CopyOf(currupted), true},
 	}
 	for _, tt := range tests {

--- a/p2p/subproto/raftwrap.go
+++ b/p2p/subproto/raftwrap.go
@@ -7,6 +7,7 @@ package subproto
 
 import (
 	"context"
+	"errors"
 	"github.com/aergoio/aergo-lib/log"
 	"github.com/aergoio/aergo/consensus"
 	"github.com/aergoio/aergo/p2p/p2pcommon"
@@ -24,6 +25,8 @@ type raftWrapperHandler struct {
 
 var _ p2pcommon.MessageHandler = (*raftWrapperHandler)(nil)
 
+var ErrUnauthorizedRaftPeer = errors.New("raft message from non-member peer")
+
 // NewGetClusterReqHandler creates handler for PingRequest
 func NewRaftWrapperHandler(pm p2pcommon.PeerManager, peer p2pcommon.RemotePeer, logger *log.Logger, actor p2pcommon.ActorService, consAcc consensus.ConsensusAccessor) *raftWrapperHandler {
 	ph := &raftWrapperHandler{
@@ -34,6 +37,9 @@ func NewRaftWrapperHandler(pm p2pcommon.PeerManager, peer p2pcommon.RemotePeer, 
 }
 
 func (ph *raftWrapperHandler) ParsePayload(rawbytes []byte) (p2pcommon.MessageBody, error) {
+	if ph.consAcc == nil || ph.consAcc.RaftAccessor().GetMemberByPeerID(ph.peer.ID()) == nil {
+		return nil, ErrUnauthorizedRaftPeer
+	}
 	return p2putil.UnmarshalAndReturn(rawbytes, &raftpb.Message{})
 }
 

--- a/syncer/syncer_busy_test.go
+++ b/syncer/syncer_busy_test.go
@@ -1,0 +1,80 @@
+package syncer
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aergoio/aergo/chain"
+	"github.com/aergoio/aergo/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleSyncStart_BusyWhileRunning covers the orphan/tip path that keeps
+// requesting SyncStart while catch-up is already running.
+//
+// Before the busy-path fix, handleSyncStart returned ErrSyncerBusy, which made
+// handleMessage log "SyncStart failed" (and SyncChain abort when NotifyC was
+// set). Busy must still notify waiters, but must not surface as a SyncStart
+// handler error.
+func TestHandleSyncStart_BusyWhileRunning(t *testing.T) {
+	localChain := chain.InitStubBlockChain(nil, 10)
+	s := NewSyncer(nil, localChain, SyncerCfg)
+	s.isRunning = true
+	seqBefore := s.GetSeq()
+
+	t.Run("without NotifyC (orphan-like)", func(t *testing.T) {
+		err := s.handleSyncStart(&message.SyncStart{
+			PeerID:   targetPeerID,
+			TargetNo: 1000,
+		})
+		assert.NoError(t, err, "busy SyncStart must not fail the handler")
+		assert.True(t, s.isRunning)
+		assert.Equal(t, seqBefore, s.GetSeq(), "must not start a second sync")
+	})
+
+	t.Run("with NotifyC (consensus SyncChain)", func(t *testing.T) {
+		notiC := make(chan error, 1)
+		err := s.handleSyncStart(&message.SyncStart{
+			PeerID:   targetPeerID,
+			TargetNo: 1000,
+			NotifyC:  notiC,
+		})
+		assert.NoError(t, err, "busy SyncStart must not fail the handler")
+
+		select {
+		case nerr := <-notiC:
+			assert.True(t, errors.Is(nerr, ErrSyncerBusy), "got %v", nerr)
+		case <-time.After(time.Second):
+			t.Fatal("expected ErrSyncerBusy on NotifyC")
+		}
+
+		assert.True(t, s.isRunning)
+		assert.Equal(t, seqBefore, s.GetSeq(), "must not start a second sync")
+	})
+}
+
+func TestHandleSyncStart_BusyDoesNotClearRunning(t *testing.T) {
+	localChain := chain.InitStubBlockChain(nil, 10)
+	s := NewSyncer(nil, localChain, SyncerCfg)
+	require.False(t, s.isRunning)
+
+	// First request should start sync (stub chain best is below target).
+	err := s.handleSyncStart(&message.SyncStart{
+		PeerID:   targetPeerID,
+		TargetNo: uint64(localChain.Best + 10),
+	})
+	require.NoError(t, err)
+	require.True(t, s.isRunning)
+	seq := s.GetSeq()
+
+	// Second request while running: same contract as orphan spam during catch-up.
+	err = s.handleSyncStart(&message.SyncStart{
+		PeerID:   targetPeerID,
+		TargetNo: uint64(localChain.Best + 20),
+	})
+	assert.NoError(t, err)
+	assert.True(t, s.isRunning)
+	assert.Equal(t, seq, s.GetSeq())
+}

--- a/syncer/syncerservice.go
+++ b/syncer/syncerservice.go
@@ -83,7 +83,8 @@ var (
 var (
 	ErrFinderInternal = errors.New("error finder internal")
 	ErrSyncerPanic    = errors.New("syncer panic")
-	ErrSyncerBusy     = errors.New("syncer is already running")
+	// ErrSyncerBusy aliases message.ErrSyncerBusy for local callers/tests.
+	ErrSyncerBusy = message.ErrSyncerBusy
 )
 
 type ErrSyncMsg struct {
@@ -333,9 +334,12 @@ func (syncer *Syncer) handleSyncStart(msg *message.SyncStart) error {
 	logger.Debug().Uint64("targetNo", msg.TargetNo).Str("peer", p2putil.ShortForm(msg.PeerID)).Msg("syncer requested")
 
 	if syncer.isRunning {
+		// Expected when tip/orphan blocks keep requesting sync during an
+		// in-flight catch-up. Wake NotifyC waiters, but do not surface as a
+		// handleMessage failure (avoids Error log spam / false sync failures).
 		logger.Debug().Uint64("targetNo", msg.TargetNo).Msg("skipped syncer is running")
 		notify(ErrSyncerBusy)
-		return ErrSyncerBusy
+		return nil
 	}
 
 	//TODO skip sync in reorgnizing

--- a/syncer/syncerservice.go
+++ b/syncer/syncerservice.go
@@ -83,6 +83,7 @@ var (
 var (
 	ErrFinderInternal = errors.New("error finder internal")
 	ErrSyncerPanic    = errors.New("syncer panic")
+	ErrSyncerBusy     = errors.New("syncer is already running")
 )
 
 type ErrSyncMsg struct {
@@ -318,17 +319,30 @@ func (syncer *Syncer) handleSyncStart(msg *message.SyncStart) error {
 	var err error
 	var bestBlock *types.Block
 
+	notify := func(err error) {
+		if msg.NotifyC == nil {
+			return
+		}
+		select {
+		case msg.NotifyC <- err:
+		default:
+			logger.Debug().Msg("failed to notify rejected sync request")
+		}
+	}
+
 	logger.Debug().Uint64("targetNo", msg.TargetNo).Str("peer", p2putil.ShortForm(msg.PeerID)).Msg("syncer requested")
 
 	if syncer.isRunning {
 		logger.Debug().Uint64("targetNo", msg.TargetNo).Msg("skipped syncer is running")
-		return nil
+		notify(ErrSyncerBusy)
+		return ErrSyncerBusy
 	}
 
 	//TODO skip sync in reorgnizing
-	bestBlock, _ = syncer.chain.GetBestBlock()
+	bestBlock, err = syncer.chain.GetBestBlock()
 	if err != nil {
 		logger.Error().Err(err).Msg("error getting block in syncer")
+		notify(err)
 		return err
 	}
 
@@ -337,6 +351,7 @@ func (syncer *Syncer) handleSyncStart(msg *message.SyncStart) error {
 	if msg.TargetNo <= bestBlockNo {
 		logger.Debug().Uint64("targetNo", msg.TargetNo).Uint64("bestNo", bestBlockNo).
 			Msg("skipped syncer. requested no is too low")
+		notify(nil)
 		return nil
 	}
 


### PR DESCRIPTION
# Raft Consensus Hardening

Reviewer notes for the security and correctness changes on top of `release/2.3.5`.

Branch: `fix/raft-consensus-2.3.5`

**Scope:** permissioned / private Raft deployments. These commits harden trust boundaries around Raft messaging, snapshots, join/recovery, and a few race/liveness bugs.

**Not included:** gas / economics changes

**Compatibility (short):** no block/tx format or state-transition hardfork. Trusted Raft members can roll binaries gradually; coordinate **PreVote** carefully (election behavior). See per-commit notes below.

---

## Commit map

| # | Commit | One-line |
|---|--------|----------|
| 1 | `b3881cd7` | bind raft messages to authenticated peer ids |
| 2 | `64d481c7` | reject unauthorized snapshots and limit snapshot allocations |
| 3 | `54cb50cc` | require quorum agreement on cluster bootstrap |
| 4 | `ac1ede38` | reject peer id mismatch when joining existing cluster |
| 5 | `e4ab2492` | sync backup chain forward before exact raft hardstate reset |
| 6 | `22bad49e` | require block signer to be a current raft member |
| 7 | `31d3bd30` | enable raft prevote |
| 8 | `a555c025` | notify syncer on busy paths and verify sync target hash |
| 9 | `6346582f` | fix leader status locking and commit progress races |
| 10 | `ee88e34b` | validate membership and conf-change inputs |

---

## 1. Bind Raft messages to authenticated peer IDs

**Commit:** `bind raft messages to authenticated peer ids`

### Problem

Raft envelopes (`raftpb.Message`) were accepted from any connected libp2p peer without checking that:

- the peer is a current cluster member, and
- `Message.From` / `Message.To` match the authenticated peer identity and this node.

A connected non-member (or a member spoofing another member’s Raft ID) could inject votes, heartbeats, or append messages and disrupt elections or log replication.

### Fix

- Added `AergoRaftAccessor.ValidateMessage(peerID, msg)`.
- `Process` validates before stepping the Raft state machine.
- Wrapper handler rejects payloads from non-members early (`ParsePayload`).
- Binding rules: peer must map to a member; `From` must equal that member’s Raft ID; `To` must equal the local Raft ID.

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Only check membership, ignore `From`/`To` | Still allows a member to spoof another member’s Raft identity |
| Mutual TLS / separate Raft port with static certs | Large operational change; libp2p already authenticates peer IDs |
| Gate behind a hardfork height | This is P2P admission, not block validity; delaying weakens security on upgrade |

### Review focus

- Honest member→member traffic still has correct `From`/`To` in the existing transport.
- Joining / recovering nodes that are not yet in membership cannot send Raft msgs until merged (intentional).

---

## 2. Reject unauthorized snapshots and limit snapshot allocations

**Commit:** `reject unauthorized snapshots and limit snapshot allocations`

### Problem

Several snapshot weaknesses:

1. Raft message envelope decode used an effectively unbounded size (`1<<63`), enabling allocation DoS.
2. Snapshot streams were not clearly restricted to cluster members; concurrent receives were unbounded.
3. Snapshot contents were not checked for membership/`ConfState` consistency before/during apply.
4. Chain sync for a snapshot did not prefer the snapshot sender; publish path did not verify the synced block hash against snapshot chain data.
5. Snapshot response body length was not capped on the sender side.

### Fix

- Cap Raft envelope decode (`maxSnapshotRaftMessageSize`) and snapshot response body size.
- Reject snapshot streams from non-members; allow only one concurrent snapshot receive.
- `ValidateMessage` for `MsgSnap` (stale term/index, non-leader sender when leader known, membership consistency).
- `validateSnapshotConsistency` + publish-time block hash check.
- Sync chain from the snapshot sender when possible; lock-safe `getMemberPeerAddress`.

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Keep unbounded decode “because DB snapshot is large” | Envelope is small; DB stream is separate — unbounded decode was unnecessary |
| Only rate-limit without auth | Does not stop malicious snapshot content from a non-member |
| Require hardfork to enable | Same as (1): defense should apply on binary upgrade |

### Review focus

- Confirm envelope limit does not break legitimate large *DB* snapshot transfers (stream after envelope).
- Concurrent snapshot limit may reject overlapping catch-ups under load (fail closed).

---

## 3. Require quorum agreement on cluster bootstrap

**Commit:** `require quorum agreement on cluster bootstrap`

### Problem

`ConcurrentClusterInfoReceiver` selected the response with the highest `BestBlockNo`. A single malicious or partitioned peer advertising an extreme height (and arbitrary membership / hardstate) could win bootstrap and feed a joining node a false cluster view or unsafe checkpoint.

### Fix

- Fingerprint responses (chain ID, cluster ID, canonical member set, hardstate term/commit).
- Require at least `len(peers)/2+1` agreeing responses.
- Among the agreeing set, pick the highest `BestBlockNo`.

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Require unanimous agreement | Fragile if one peer is down or slightly divergent |
| Trust only designated seed peers | Extra config; quorum of connected peers matches Raft threat model better |
| Keep highest tip but verify signatures on membership | No signed cluster attestation exists today |

### Review focus

- Join needs enough live peers for quorum; small/partitioned peer sets may fail closed (safer).
- Hardstate is part of the fingerprint: disagreeing checkpoints cannot form a majority.

---

## 4. Reject peer ID mismatch when joining existing cluster

**Commit:** `reject peer id mismatch when joining existing cluster`

### Problem

When merging into an existing cluster, a name match with a **different** libp2p peer ID was only logged. Join could continue with the wrong identity mapping, causing later auth/transport confusion or impersonation of a member slot.

### Fix

`ValidateAndMergeExistingCluster` returns `false` if the remote member’s peer ID does not match this node’s peer ID (fatal on import).

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Auto-rewrite remote peer ID to local | Silently changes cluster identity; dangerous |
| Allow mismatch with operator flag | Easy to misuse during DR; explicit config of the correct peer key is clearer |

### Review focus

- Disaster recovery that promotes a full-node backup onto a BP must use the **member slot’s** peer key/identity.

---

## 5. Sync backup chain forward before exact Raft hardstate reset

**Commit:** `sync backup chain forward before exact raft hardstate reset`

### Problem

`usebackup` recovery asked live BPs for a Raft hardstate matching the backup tip, then `ResetWAL`’d to that checkpoint.

Previously, if the exact entry was missing (WAL compact), providers could return a **newer** entry or the latest snapshot. That pairs a high Raft commit/applied index with an older chain tip and can let the recovering node **vote or lead before it has that state**.

A first hardening attempt that **only** accepted exact hardstate (fail otherwise) was too harsh for DR: full-node backups are often older than retained Raft history, and sync-from-genesis is too slow.

### Fix (selected)

Keep **exact-only** hardstate for `ResetWAL`, but make recovery fast:

1. Providers still return membership if exact hardstate is unavailable (non-fatal).
2. Recovering node with `usebackup` and no exact hardstate **syncs only the delta** backup tip → live cluster tip.
3. Retries hardstate for the new tip, then `ResetWAL`.

So Raft never jumps ahead of the chain; DR stays incremental-sync fast.

### Alternatives considered

| Alternative | Pros | Cons / why not primary |
|-------------|------|-------------------------|
| Exact hardstate or fail | Safest one-liner | Rejects typical stale full-node backups |
| Restore “newer hardstate” fallback | Fast one-shot | Unsafe vote/lead with fabricated applied state |
| Newer hardstate + stay non-promotable until catch-up | Fast + safer | More state machine complexity; Tick gating alone is easy to get wrong |
| Empty WAL + leader `MsgSnap` only | No invented hardstate | Depends entirely on snapshot path reliability |
| **Sync-forward then exact reset (chosen)** | Fast delta sync; preserves exactness | Needs live peers with tip status; brief wait if LastStatus not ready |

### Review focus

- Confirm `ClusterInfo` soft-fail of hardstate does not weaken join when membership itself is wrong (still needs quorum agreement from commit 3).
- Sync target is chosen from **cluster member** peers’ `LastStatus` (not arbitrary watchers).
- After sync, tip must still be within retained Raft history on providers (normally true for current tip).

---

## 6. Require block signer to be a current Raft member

**Commit:** `require block signer to be a current raft member`

### Problem

`IsBlockValid` only ensured the block public key parsed. Any key with a valid signature could pass consensus-level validation, even if the producer was not a current Raft member. That matters if a non-member block is injected via P2P `AddBlock` / sync paths that call `IsBlockValid` during execute.

### Fix

Reject blocks whose producer peer ID is not in the current cluster member set (`bf.bpc`).

### Alternatives considered

| Alternative | Why not selected / caveat |
|-------------|---------------------------|
| Validate membership **at block height** (historical) | More correct across add/remove; needs membership history — not available as a simple API today |
| Hardfork-gated activation | Cleaner on public networks; for trusted private Raft, tip blocks are already member-signed, so immediate enable is usually fine |
| Rely only on Raft log commit path | Misses non-Raft P2P block injection paths |

### Review focus

- **Caveat:** check uses *current* membership. Deep sync/re-execute of blocks signed by a since-removed member can fail. Worth a follow-up if you reorg/sync across membership changes often.
- On a healthy Raft tip (leader ∈ members), old and new binaries agree — no practical tip fork among trusted BPs.

---

## 7. Enable Raft PreVote

**Commit:** `enable raft prevote`

### Problem

Without PreVote, a partitioned or restarting member can start a real election, inflate its term, then rejoin and force the leader to step down even when it cannot win. That causes unnecessary leadership flaps (classic Raft disruption).

### Fix

Set `PreVote: true` in Raft config. Campaigners must win a pre-vote (without bumping term) before a real election.

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Leave PreVote off | Keeps known disruption mode |
| Cluster-version negotiated enable (etcd-style) | Aergo Raft has no cluster feature negotiation today |
| Hardfork height gate | PreVote is process-wide election behavior, not per-block validation |

### Review focus

- **Rolling upgrade:** mixed PreVote / non-PreVote members can behave oddly during elections. Prefer upgrading all Raft members in a short window.
- PreVote does **not** stop a malicious member that is caught up and can win a majority — that is inherent to Raft.
- Combined with commit 1, outsiders should not inject votes at all.

---

## 8. Notify syncer on busy paths and verify sync target hash

**Commit:** `notify syncer on busy paths and verify sync target hash`

### Problem

1. If the syncer was already running or the target was already reached, callers waiting on `NotifyC` could hang (no notification).
2. After sync, consensus did not verify that the block at `targetNo` matched the requested `targetHash` (snapshot / consensus sync could accept the wrong block at that height).

### Fix

- Notify waiters on busy / already-synced / error paths (`ErrSyncerBusy` when busy).
- `SyncChain` verifies hash after sync (and if already at/above target).
- Use buffered notify channel.

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Timeout-only on waiter side | Masks the bug; still races |
| Verify only inside syncer | Consensus callers still need a hash guarantee at their API |

### Review focus

- Backup recovery (commit 5) and snapshot sync both depend on reliable `SyncChain` completion notification.

---

## 9. Fix leader status locking and commit progress races

**Commit:** `fix leader status locking and commit progress races`

### Problem

Several concurrency bugs:

- `updateLeader` / `GetLeaderStatus` used the wrong mutex / returned a copy that included the mutex unsafely.
- `CommitProgress` getters returned pointers to internal fields under brief lock (TOCTOU / race with `-race`).
- Snapshot sender could leave the write goroutine orphaned on stop/timeout (race / leak).
- `IsIDRemoved` / member lookups lacked consistent locking in some paths.
- Minor nil guard on duplicate-commit detection when request progress is empty.

### Fix

- Lock `leaderStatus` properly; return a value copy of status fields.
- Return copies from `GetConnect` / `GetRequest`.
- Join writer completion on snapshot send cancel/timeout; cap already added in commit 2.
- Lock cluster for remove-ID / member getters as needed.

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Channel-serialize all Raft status access | Larger refactor |
| Ignore races under “Raft is single-threaded” | Status and P2P run concurrently with the ready loop |

### Review focus

- Run with `-race` on `raftv2` / `raftsupport` if not already in CI for this branch.

---

## 10. Validate membership and conf-change inputs

**Commit:** `validate membership and conf-change inputs`

### Problem

Membership and conf-change paths trusted partially validated attributes:

- Peer IDs were not parsed in `Member.IsValid`.
- Nil `MembershipChange` / attrs could panic or proceed oddly.
- Snapshot recover / add paths did not consistently validate members.
- Malformed conf-change protobuf context could `Fatal` the process instead of returning an error.

### Fix

- Validate peer ID bytes in `Member.IsValid`.
- Nil-guard membership RPCs / `makeProposal` / `NewMemberFrom*`.
- Validate members when recovering from snapshot.
- Unmarshal conf-change errors become returned errors (no process fatal on bad entry).

### Alternatives considered

| Alternative | Why not selected |
|-------------|------------------|
| Keep Fatal on bad conf-change | Turns corrupt/malicious log data into permanent outage |
| Strict validate only on AddMember RPC | Leaves snapshot recover and WAL replay gaps |

### Review focus

- Existing clusters with historically weird peer ID encodings would fail `IsValid` — unlikely if peers were always libp2p IDs.

---

## Suggested test plan for reviewers

- [ ] Unit: `go test ./consensus/impl/raftv2/ ./p2p/raftsupport/ ./p2p/subproto/ ./consensus/chain/ ./syncer/`
- [ ] Race: same packages with `-race` (especially snapshot sender + leader status).
- [ ] 3-node Raft smoke: rolling restart of one BP; confirm election stability (PreVote).
- [ ] Join new member with correct peer ID; confirm mismatch is rejected.
- [ ] `usebackup` DR: copy slightly lagging full-node data to a BP slot; confirm delta sync then WAL reset (not fail-closed on “old tip”).
- [ ] Negative: non-member peer cannot drive Raft votes/snapshots.
- [ ] Snapshot catch-up of a lagging follower still succeeds under size limits.

---

## Residual risks / follow-ups

1. **`IsBlockValid` uses current membership** — consider height-indexed membership if deep sync across removes is required.
2. **PreVote rolling upgrade** — document ops procedure (brief coordinated restart).
3. **No cluster feature negotiation** — unlike etcd, flags flip per binary.
4. **Trusted-member model** — a compromised BP that holds a majority vote can still elect itself; these patches remove *outsider* and *spoofing* paths, not Byzantine majority failure.