### PR TITLE
Make legacy branch testable

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    env:
+      TURN_OFF_CONTROL_COMPACTION: true
+      TMPDIR: ${{ runner.temp }}
 
     steps:
 
@@ -49,7 +52,6 @@ jobs:
       uses: paambaati/codeclimate-action@v4
       env:
         CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-        TURN_OFF_CONTROL_COMPACTION: true
       with:
         coverageCommand: go test -timeout 999s -coverprofile build/c.out ./...
         prefix: github.com/aergoio/aergo/v2

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -49,6 +49,7 @@ jobs:
       uses: paambaati/codeclimate-action@v4
       env:
         CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+        TURN_OFF_CONTROL_COMPACTION: true
       with:
         coverageCommand: go test -timeout 999s -coverprofile build/c.out ./...
         prefix: github.com/aergoio/aergo/v2

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build_and_unittest:
     runs-on: ubuntu-latest
+    env:
+      TURN_OFF_CONTROL_COMPACTION: true
+      TMPDIR: ${{ runner.temp }}
 
     steps:
 

--- a/.github/workflows/short_test.yml
+++ b/.github/workflows/short_test.yml
@@ -24,6 +24,9 @@ jobs:
     if: needs.check_if_pull_request.outputs.is_pull_request != 'true'
 
     runs-on: ubuntu-latest
+    env:
+      TURN_OFF_CONTROL_COMPACTION: true
+      TMPDIR: ${{ runner.temp }}
 
     steps:
 


### PR DESCRIPTION
It appears that actions on branches derived from the release/2.3.x branch will execute as expected only if this PR is merged, since any of GitHub actions in all branches are executed based on files in the base branch,

This PR itself only changes a single environment variable, so it is no harm to other branches, I guess.